### PR TITLE
style: 프로필 이미지 컴포넌트에서 size 타입 제거 및 반응형 스타일 추가

### DIFF
--- a/src/app/technician/profile/[id]/page.tsx
+++ b/src/app/technician/profile/[id]/page.tsx
@@ -20,7 +20,8 @@ async function fetchUser(userId: string) {
 }
 
 export default async function ProfilePage({ params }: { params: { id: string } }) {
-  const user = await fetchUser(params.id);
+  const { id } = await params;
+  const user = await fetchUser(id);
 
   const defaultCardData = {
     profileData1: {

--- a/src/components/ui/profile/ProfileImage.tsx
+++ b/src/components/ui/profile/ProfileImage.tsx
@@ -3,18 +3,16 @@ import clsx from "clsx";
 
 interface ProfileImageProps {
   src: string;
-  size?: "sm" | "md" | "lg";
   shape?: "circle" | "square";
 }
 
-const sizeClasses = {
-  sm: "w-12 h-12",
-  md: "w-21 h-21",
-  lg: "w-40 h-40",
+const shapeClasses = {
+  circle: "min-w-12 w-12 h-12 lg:min-w-21 lg:w-21 lg:h-21",
+  square: "w-25 h-25 lg:min-w-40 lg:w-40 lg:h-40",
 };
 
-export default function ProfileImage({ src, size = "md", shape = "circle" }: ProfileImageProps) {
-  const containerClasses = clsx("relative", "border-2", "overflow-hidden", sizeClasses[size], {
+export default function ProfileImage({ src, shape = "circle" }: ProfileImageProps) {
+  const containerClasses = clsx("relative", "border-2", "overflow-hidden", shapeClasses[shape], {
     "rounded-full": shape === "circle",
     "rounded-lg": shape === "square",
   });


### PR DESCRIPTION
이슈 번호 : #1

작업요약 : 프로필 이미지 컴포넌트, 반응형 스타일 추가

[작업 내역]
- [X] 프로필 컴포넌트에서 size 타입 삭제
- [X] 1024px(lg) 이상 구간에서 반응형 스타일 추가 