### PR TITLE
Feat/랜딩 로그인

### DIFF
--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import MovingSmall from "@/assets/img/Landing1.svg";
 import MovingHome from "@/assets/img/Landing2.svg";
 import MovingBusiness from "@/assets/img/Landing3.svg";
@@ -6,8 +7,31 @@ import MovingSmallMd from "@/assets/img/Landing_md_01.svg";
 import MovingHomeMd from "@/assets/img/Landing_md_02.svg";
 import MovingBusinessMd from "@/assets/img/Landing_md_03.svg";
 import Image from "next/image";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+type UserResponse = {
+  success: boolean;
+  data: {
+    id: string;
+    email: string;
+    name: string;
+    role: "DRIVER" | "CONSUMER";
+    createdAt: string;
+    isProfileRegistered: boolean;
+  };
+};
 
 export default function Landing() {
+  const queryClient = useQueryClient();
+  const { data: user } = useQuery<UserResponse | null, Error>({
+    queryKey: ["user"],
+    queryFn: () => queryClient.getQueryData<UserResponse>(["user"]) ?? null,
+    staleTime: Infinity,
+  });
+
+  const isLoggedIn = !!user?.success;
+
+  console.log("user", user, "succ", isLoggedIn);
   return (
     <div className="min-h-screen bg-[#F4F7FB] outline-none">
       <div className="flex min-h-screen flex-col items-center justify-between caret-transparent outline-none focus:ring-0">
@@ -66,12 +90,16 @@ export default function Landing() {
         </div>
 
         <div className="mt-8 flex w-full flex-col items-center gap-4 pb-10 lg:flex-row lg:justify-center lg:gap-6">
-          <Button className="w-[320px]" radius="full">
-            로그인
-          </Button>
-          <Button className="w-[320px]" variant="secondary" radius="full">
-            회원가입
-          </Button>
+          {!isLoggedIn && (
+            <>
+              <Button className="w-[320px]" radius="full">
+                로그인
+              </Button>
+              <Button className="w-[320px]" variant="secondary" radius="full">
+                회원가입
+              </Button>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,14 +4,43 @@ import SocialLogin from "./components/SocialLogin";
 import SwitchButton from "./components/SwitchButton";
 import LogoText from "@/assets/icon/Logo-2.svg";
 import Image from "next/image";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { useState } from "react";
+type UserResponse = {
+  success: boolean;
+  data: {
+    id: string;
+    email: string;
+    name: string;
+    role: "DRIVER" | "CONSUMER";
+    createdAt: string;
+    isProfileRegistered: boolean;
+  };
+};
+
 export default function Login() {
   const pretendardXs = "text-[#6B6B6B] font-pretendard text-[16px] font-normal leading-[18px]";
   const pretendardXsUnderline =
     "text-[var(--Primary-blue-300,#1B92FF)] font-pretendard text-[16px] font-semibold leading-[20px] underline";
 
   const [role, setRole] = useState<"CONSUMER" | "DRIVER">("CONSUMER");
+
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const { data: user } = useQuery<UserResponse | null, Error>({
+    queryKey: ["user"],
+    queryFn: () => queryClient.getQueryData<UserResponse>(["user"]) ?? null,
+    staleTime: Infinity,
+  });
+
+  useEffect(() => {
+    if (user?.success) {
+      router.replace("/landing");
+    }
+  }, [user, router]);
 
   return (
     <div className="mt-10 flex justify-center">


### PR DESCRIPTION
## 개요 
로그인된 상태에서 로그인 페이지 접근 시 랜딩 페이지로 리다이렉트되도록 구현
랜딩 페이지에서 로그인/회원가입 버튼이 로그인된 상태에서도 표시되는 현상 수정

## 수정내용 
로그인 상태 판별 후 로그인 페이지 접근 시 useRouter를 이용한 리다이렉트 추가
랜딩 페이지 버튼 렌더링 조건 수정 (로그인 상태일 때 숨김 처리)

## 코드개선할점
현재 사용자 정보 조회 코드가 페이지마다 중복됨(Type도 동일)
추후 custom hook 등으로 리팩토링하여 중복 제거 예정

## 코드리뷰 요청사항
유지보수측면에서 코드리뷰 부탁드리겠습니다

## 결과이미지

<img width="1664" height="1129" alt="화면 캡처 2025-09-29 170925" src="https://github.com/user-attachments/assets/990f8605-1867-4551-8ffc-150652d45166" />

