### PR TITLE
버튼 컴포넌트 children 혼용 문제 수정

### DIFF
--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -162,7 +162,6 @@ export default function Signup() {
           </label>
         ))}
         <Button className="mt-14 mb-4" type="submit" text="시작하기" disabled />
-        <Button />
       </form>
 
       <div className="mx-auto flex max-w-160 flex-row justify-center">

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,4 +1,5 @@
-import type { ButtonHTMLAttributes, ReactNode, MouseEventHandler } from "react";
+"use client";
+import type { ButtonHTMLAttributes, ReactNode, MouseEvent as ReactMouseEvent } from "react";
 import clsx from "clsx";
 import writingIcon from "@/assets/icon/writing.svg";
 import Image from "next/image";
@@ -28,7 +29,8 @@ type Size = "sm" | "md" | "lg" | "xl";
 type Radius = "default" | "full";
 type TextSize = "desktop" | "mobile";
 
-/** 공통(버튼 고유) 속성들: children, onClick은 재정의 위해 제외 */
+type ButtonClickHandler = (event: ReactMouseEvent<HTMLButtonElement>) => void | Promise<void>;
+
 type BaseProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children" | "onClick"> & {
   variant?: Variant;
   size?: Size;
@@ -44,7 +46,7 @@ type BaseProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children" | "onC
   style?: React.CSSProperties;
 
   /** 허용 범위 확장: 이벤트 핸들러 or 콜백 둘 다 가능 */
-  onClick?: MouseEventHandler<HTMLButtonElement> | (() => void);
+  onClick?: ButtonClickHandler;
 };
 
 /** 둘 중 하나만 허용 (XOR):
@@ -116,6 +118,8 @@ export default function Button(props: ButtonProps) {
   // children > text > 기본 "버튼"
   const label: ReactNode = "children" in props ? props.children : (props.text ?? "버튼");
 
+  const handleClick = onClick;
+
   return (
     <button
       type={type}
@@ -139,8 +143,7 @@ export default function Button(props: ButtonProps) {
       style={style}
       // onClick 정규화: MouseEventHandler든 () => void든 모두 호출
       onClick={(e) => {
-        if (!onClick) return;
-        (onClick as any)(e); // 무인자 콜백은 여분 인자(e)를 무시하므로 안전
+        handleClick?.(e);
       }}
       {...rest}
     >


### PR DESCRIPTION
- 기존 설계(text 방식)
    - `<Button text="블라블라" />`
    - props로 전달 받아 버튼 내 텍스트 표시
- 문제점
    - `<Button>블라블라<Button />`
    - 버튼 컴포넌트의 기본 동작인 `children`방식이 혼용되어 사용됨
    - 위 두 가지 방식을 각각 사용하면 문제 없으나 실수로
    `<Button text=”블라블라”>블뤠블뤠<Button />`이렇게 사용하면 오류 없이 children 방식이 적용되나 api사용시에 2개 값이 충돌 할 가능성이 있음

### 작업 내용

- [x]  Button 컴포넌트: `children` ↔ `text` XOR 정책
    - `children`과 `text`를 동시에 넘겨 생기는 의도 불명/묵살 문제 방지
    - 호출부 API를 단순화하고 일관된 사용 규칙 확립
    
    ---
    
    - `ButtonProps`를 XOR 타입으로 변경
        - `WithChildren`: `children`만 허용 (`text?: never`)
        - `WithText`: `text`만 허용 (`children?: never`)
        - `WithNone`: 둘 다 생략 시 기본 라벨 `"버튼"` 표시 (기존 동작 유지)
    - `children`과 `text`를 **동시에 작성하면 컴파일 에러** 발생(빌드 전 차단)
