### PR TITLE
Feat/page profile consumer

### DIFF
--- a/src/app/mypage/profile/components/ConsumerProfileForm.tsx
+++ b/src/app/mypage/profile/components/ConsumerProfileForm.tsx
@@ -96,7 +96,7 @@ export default function ConsumerProfileForm({ initialData }: ConsumerFormProps) 
           </h2>
           {!formData.consumerId && (
             <p className="text-xs text-gray-600 lg:text-lg">
-              "추가 정보를 입력하여 회원가입을 완료해주세요.
+              추가 정보를 입력하여 회원가입을 완료해주세요.
             </p>
           )}
         </div>

--- a/src/app/mypage/profile/components/ConsumerProfileForm.tsx
+++ b/src/app/mypage/profile/components/ConsumerProfileForm.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { ConsumerProfileData } from "@/types/card";
+import Button from "@/components/ui/Button";
+import TagForm from "./TagForm";
+import { MoveTypeMap } from "@/types/moveTypes";
+import { AreaMap, AreaType } from "@/types/areaTypes";
+import ImageInputArea from "./ImageInputArea";
+
+const getServiceTags = () => {
+  return Object.keys(MoveTypeMap).map((key) => {
+    const serverKey = key as keyof typeof MoveTypeMap;
+    return {
+      value: serverKey,
+      label: MoveTypeMap[serverKey].content,
+    };
+  });
+};
+const SERVICE_TAGS = getServiceTags();
+
+// const getRegionTags = () => {
+//   return Object.keys(AreaMap).map((key) => ({
+//     value: key,
+//     label: AreaMap[key],
+//   }));
+// };
+// const REGION_TAGS = getRegionTags();
+
+const regions = [
+  "서울",
+  "경기",
+  "인천",
+  "강원",
+  "충북",
+  "충남",
+  "세종",
+  "대전",
+  "전북",
+  "전남",
+  "광주",
+  "경북",
+  "경남",
+  "대구",
+  "울산",
+  "부산",
+  "제주",
+];
+
+interface ConsumerFormProps {
+  initialData: ConsumerProfileData;
+}
+
+export default function ConsumerProfileForm({ initialData }: ConsumerFormProps) {
+  const safeInitialData: ConsumerProfileData = initialData || {
+    consumerId: "",
+    image: "",
+    serviceType: [],
+    areas: "",
+  };
+
+  const [formData, setFormData] = useState<ConsumerProfileData>(safeInitialData);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
+
+  const [selectedServices, setSelectedServices] = useState<string[]>([]);
+  const [selectedAreas, setSelectedAreas] = useState<string[]>([]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setMessage("");
+
+    const isNewUser = !formData.consumerId; // consumerId 없으면 등록 모드
+    const actionText = isNewUser ? "등록" : "수정";
+
+    try {
+      console.log(`소비자 프로필 ${actionText} 요청 데이터:`, formData);
+      // TODO: 실제 API 호출 (Firestore updateDoc 또는 addDoc)
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      setMessage(`프로필이 성공적으로 ${actionText}되었습니다.`);
+    } catch (error) {
+      setMessage(`프로필 ${actionText} 중 오류가 발생했습니다.`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center">
+      <div className="flex w-full flex-col gap-5 pt-4 pb-10 lg:gap-16 lg:pt-6">
+        <div className="flex flex-col gap-4 border-b border-gray-200 pb-4 lg:gap-8 lg:pb-8">
+          <h2 className="text-2xl font-bold text-gray-800 lg:text-3xl">
+            프로필 {formData.consumerId ? "수정" : "등록"}
+          </h2>
+          {!formData.consumerId && (
+            <p className="text-xs text-gray-600 lg:text-lg">
+              "추가 정보를 입력하여 회원가입을 완료해주세요.
+            </p>
+          )}
+        </div>
+        <form onSubmit={handleSubmit} className="w-full space-y-8">
+          <div className="flex w-full flex-wrap gap-8">
+            <div className="flex w-full flex-col gap-6">
+              <ImageInputArea />
+              {/* 선호 서비스 유형 태그 */}
+              <TagForm
+                selectedTags={selectedServices}
+                setSelectedTags={setSelectedServices}
+                Tags={["소형이사", "가정이사", "사무실이사"]}
+                label="이용 서비스"
+                subText="* 이용 서비스는 중복 선택 가능하며, 언제든 수정 가능해요!"
+                colType="flex"
+              />
+
+              {/* 관심 지역 태그 */}
+              <TagForm
+                selectedTags={selectedServices}
+                setSelectedTags={setSelectedServices}
+                Tags={regions}
+                label="내가 사는 지역"
+                subText="*내가 사는 지역은 언제든 수정 가능해요!"
+                colType="grid"
+              />
+            </div>
+          </div>
+
+          {/* 저장 버튼 */}
+          <div className="mt-8 flex w-full flex-col justify-end gap-4 pt-4 lg:flex-row">
+            {message && (
+              <p
+                className={`mr-4 self-center font-medium ${message.includes("오류") ? "text-warning" : "text-green-600"}`}
+              >
+                {message}
+              </p>
+            )}
+            <Button type="submit" className="w-full px-8 py-2" disabled={loading}>
+              {loading
+                ? `${formData.consumerId ? "수정" : "등록"} 중...`
+                : `${formData.consumerId ? "수정하기" : "시작하기"}`}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/mypage/profile/components/DriverProfileForm.tsx
+++ b/src/app/mypage/profile/components/DriverProfileForm.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { DriverProfileData } from "@/types/card";
+import InputArea from "./InputArea";
+import ImageInputArea from "./ImageInputArea";
+import TagForm from "./TagForm";
+import Button from "@/components/ui/Button";
+
+interface DriverFormProps {
+  initialData: DriverProfileData;
+  userId: string;
+}
+
+export default function DriverProfileForm({ initialData, userId }: DriverFormProps) {
+  const regions = [
+    "서울",
+    "경기",
+    "인천",
+    "강원",
+    "충북",
+    "충남",
+    "세종",
+    "대전",
+    "전북",
+    "전남",
+    "광주",
+    "경북",
+    "경남",
+    "대구",
+    "울산",
+    "부산",
+    "제주",
+  ];
+  const [selectedServices, setSelectedServices] = useState<string[]>([]);
+  const [formData, setFormData] = useState<DriverProfileData>(initialData);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
+
+  return (
+    <>
+      <div className="flex items-center justify-center">
+        <div className="mt-5 flex w-full max-w-[424px] flex-col items-center justify-center p-6 lg:max-w-[1200px]">
+          <div className="flex w-full flex-col lg:flex-row lg:gap-15">
+            <div className="flex w-full flex-col gap-4 lg:w-1/2">
+              <div className="w-full">
+                <div className="flex w-full">
+                  <p className="w-full border-b border-[#F2F2F2] pb-4 text-[18px] leading-[26px] font-bold text-[#1F1F1F]">
+                    프로필수정
+                  </p>
+                </div>
+                <InputArea label="별명" />
+                <ImageInputArea />
+                <InputArea label="경력" />
+                <InputArea label="한 줄 소개" />
+
+                <div className="mt-4 lg:hidden">
+                  <TagForm
+                    Tags={["소형이사", "가정이사", "사무실이사"]}
+                    label="상세설명"
+                    colType="flex"
+                    selectedTags={selectedServices}
+                    setSelectedTags={setSelectedServices}
+                  />
+                  <TagForm
+                    selectedTags={selectedServices}
+                    setSelectedTags={setSelectedServices}
+                    Tags={regions}
+                    label="가능구역"
+                    colType="grid"
+                  />
+                </div>
+              </div>
+
+              <div className="mt-4 w-full">
+                <InputArea label="상세 설명" type="textArea" borderOption="not" />
+              </div>
+            </div>
+
+            <div className="hidden gap-4 lg:flex lg:w-1/2 lg:flex-col">
+              <TagForm
+                selectedTags={selectedServices}
+                setSelectedTags={setSelectedServices}
+                Tags={["소형이사", "가정이사", "사무실이사"]}
+                label="상세설명"
+                colType="flex"
+              />
+              <TagForm
+                selectedTags={selectedServices}
+                setSelectedTags={setSelectedServices}
+                Tags={regions}
+                label="가능구역"
+                colType="grid"
+              />
+            </div>
+          </div>
+
+          <div className="mt-4 flex w-full flex-col gap-3 lg:w-full lg:flex-row">
+            <Button className="w-full lg:order-2" text="수정하기" />
+            <Button className="w-full lg:order-1" variant="secondary" text="취소" />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/mypage/profile/components/ImageInputArea.tsx
+++ b/src/app/mypage/profile/components/ImageInputArea.tsx
@@ -18,10 +18,10 @@ export default function ImageInputArea({ size = "w-32 h-32" }: ImageInputAreaPro
     }
   };
   return (
-    <div className="flex flex-col items-start gap-2 border-b border-[#F2F2F2] pb-8">
+    <div className="flex flex-col items-start gap-2 border-b border-gray-200 pb-8">
       <label
         htmlFor="imageUpload"
-        className="font-Pretendard text-[16px] leading-[26px] font-semibold text-[var(--Black-Black-300,#373737)]"
+        className="font-Pretendard leading-[26px] font-semibold lg:text-xl"
       >
         프로필 이미지
       </label>

--- a/src/app/mypage/profile/components/InputArea.tsx
+++ b/src/app/mypage/profile/components/InputArea.tsx
@@ -9,13 +9,13 @@ interface InputAreaProps {
 }
 
 export default function InputArea({ label, type = "basic", borderOption }: InputAreaProps) {
-  const containerClass = clsx("mt-4 pb-8", borderOption !== "not" && "border-b border-[#F2F2F2]");
+  const containerClass = clsx("mt-4 pb-8", borderOption !== "not" && "border-b border-gray-200");
   return (
     <div className={containerClass}>
       <label className="font-Pretendard text-[16px] leading-[26px] font-semibold text-[var(--Black-Black-300,#373737)]">
         {label}
       </label>
-      <Input className="bg-[#f1efef]" type={type} value="a" onChange={() => {}}></Input>
+      <Input className="bg-gray-100" type={type} value="a" onChange={() => {}}></Input>
     </div>
   );
 }

--- a/src/app/mypage/profile/components/TagForm.tsx
+++ b/src/app/mypage/profile/components/TagForm.tsx
@@ -7,6 +7,7 @@ interface TagFormProps {
   Tags: string[];
   colType: "flex" | "grid"; // flex: 자동 줄 바꿈, grid: 지정 컬럼
   label: string;
+  subText?: string;
   selectedTags: string[];
   setSelectedTags: (tags: string[]) => void;
 }
@@ -16,6 +17,7 @@ export default function TagForm({
   colType,
   label,
   selectedTags,
+  subText,
   setSelectedTags,
 }: TagFormProps) {
   const handleTagClick = (tag: string) => {
@@ -27,13 +29,14 @@ export default function TagForm({
   };
 
   const containerClass =
-    colType === "flex"
-      ? "flex flex-wrap gap-2"
-      : "grid grid-cols-[52px_52px_52px_52px_52px] grid-rows-[h-fit] gap-2";
+    colType === "flex" ? "flex flex-wrap gap-2" : "w-fit grid grid-cols-5 grid-rows-[h-fit] gap-2";
 
   return (
-    <div className="mt-4 border-b border-[#F2F2F2] pb-8">
-      <label className="mb-2 block font-medium">{label}</label>
+    <div className="mt-4 flex flex-col gap-4 border-b border-gray-200 pb-8 lg:gap-8">
+      <div className="flex flex-col gap-1">
+        <label className="block font-semibold lg:text-xl">{label}</label>
+        {subText && <p className="text-xs text-gray-400 lg:text-base">{subText}</p>}
+      </div>
       <div className={containerClass}>
         {Tags.map((tag) => {
           const isSelected = selectedTags.includes(tag);
@@ -42,7 +45,7 @@ export default function TagForm({
               key={tag}
               onClick={() => handleTagClick(tag)}
               className={clsx("w-fit cursor-pointer rounded-full transition", {
-                "border-2 border-blue-500 bg-blue-100": isSelected,
+                "border-primary bg-primary-lightest border": isSelected,
                 "border border-gray-300 bg-white": !isSelected,
               })}
             >

--- a/src/app/mypage/profile/edit/page.tsx
+++ b/src/app/mypage/profile/edit/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 import Input from "@/components/ui/Input";
-import InputArea from "./components/InputArea";
+import InputArea from "../components/InputArea";
 import upload from "@/assets/img/upload.svg";
-import ImageInputArea from "./components/ImageInputArea";
-import TagForm from "./components/TagForm";
+import ImageInputArea from "../components/ImageInputArea";
+import TagForm from "../components/TagForm";
 import Button from "@/components/ui/Button";
 import { useState } from "react";
 

--- a/src/app/mypage/profile/page.tsx
+++ b/src/app/mypage/profile/page.tsx
@@ -1,0 +1,83 @@
+// app/profile/page.tsx
+
+import {
+  DriverUser,
+  ConsumerUser,
+  ConsumerProfileData,
+  DriverProfileData,
+  UserData,
+} from "@/types/card";
+import ConsumerProfileForm from "./components/ConsumerProfileForm";
+import DriverProfileForm from "./components/DriverProfileForm";
+
+async function getCurrentUser(): Promise<UserData | null> {
+  const isDriver = false; // 테스트를 위해 Driver/Consumer를 전환 가능
+
+  if (isDriver) {
+    const driverProfile: DriverProfileData = {
+      driverId: "d-id-123",
+      nickname: "베스트 드라이버",
+      image: "/images/avatars/avatartion1.jpg",
+      reviewCount: 10,
+      rating: 4.8,
+      careerYears: 5,
+      confirmedCount: 200,
+      likes: {},
+    };
+
+    const driverUser: DriverUser = {
+      userId: "d123",
+      name: "홍길동",
+      role: "DRIVER",
+      profile: driverProfile,
+      phoneNumber: "010-1234-5678",
+    };
+    return driverUser;
+  } else {
+    const consumerProfile: ConsumerProfileData | null = null;
+    // const consumerProfile: ConsumerProfileData | null = {
+    //  consumerId: "c-id-456",
+    // image: "/images/avatars/avatartion5.jpg",
+    // serviceType: []
+    // areas:
+    // };
+
+    const consumerUser: ConsumerUser = {
+      userId: "c456",
+      name: "김철수",
+      role: "CONSUMER",
+      profile: consumerProfile,
+      phoneNumber: "010-9876-5432",
+    };
+    return consumerUser;
+  }
+}
+
+// ----------------------------------------------------
+// 메인 서버 컴포넌트
+// ----------------------------------------------------
+export default async function ProfilePage() {
+  const user = await getCurrentUser();
+  if (!user) {
+    // 인증되지 않은 사용자 처리
+    return <div>로그인이 필요합니다.</div>;
+  }
+
+  if (user.role === "DRIVER") {
+    const profileData = user.profile as DriverProfileData;
+
+    return (
+      <main className="container mx-auto p-4">
+        <DriverProfileForm initialData={profileData} userId={user.userId} />
+      </main>
+    );
+  } else {
+    // user.role === "CONSUMER"
+    const profileData = user.profile as ConsumerProfileData;
+    return (
+      <main className="container mx-auto px-4 lg:max-w-[686px]">
+        <ConsumerProfileForm initialData={profileData} />
+      </main>
+    );
+  }
+}

--- a/src/components/ui/Tag.tsx
+++ b/src/components/ui/Tag.tsx
@@ -84,13 +84,13 @@ export default function Tag({ type, size = "md", content, borderType, selected }
   const containerClass = clsx(
     "inline-flex items-center px-2 whitespace-nowrap h-8 flex-shrink-0 gap-2",
     selected
-      ? "bg-blue-100 text-blue-600"
+      ? "bg-primary-light text-primary"
       : ["smallMove", "homeMove", "officeMove"].includes(type)
         ? "bg-primary-light text-primary"
         : type === "requestQuote"
           ? "bg-warning-light text-warning"
           : "bg-gray-100 text-black",
-    borderType === "radius" ? "rounded-full" : "rounded-md"
+    borderType === "radius" ? "px-3 py-1.5 rounded-full lg:px-5 lg:py-2.5" : "rounded-md"
   );
 
   return (

--- a/src/components/ui/card/DefaultCard.tsx
+++ b/src/components/ui/card/DefaultCard.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import BaseCard, { CommonCardProps } from "./BaseCard";
 import CardText from "./CardText";
 import Tag from "../Tag";
-import { DriverUser } from "@/types/card";
+import { DriverProfileData, DriverUser } from "@/types/card";
 import { MoveTypeMap } from "@/types/moveTypes";
 import UserProfileArea from "../profile/UserProfileArea";
 import { isDriverUser } from "@/utils/type-guards";
@@ -16,7 +16,7 @@ export default function DefaultCard({ user, request, quotation }: CommonCardProp
   }
   const driverUser = user as DriverUser;
   const profileData = driverUser.profile;
-  const { nickname, oneLiner, rating, confirmedCount, driverServiceTypes } = profileData;
+  const { oneLiner, driverServiceTypes } = profileData as DriverProfileData;
   const price = quotation?.price;
 
   return (

--- a/src/components/ui/card/OrderCard.tsx
+++ b/src/components/ui/card/OrderCard.tsx
@@ -6,7 +6,7 @@ import CardText from "./CardText";
 import Tag from "../Tag";
 import Button from "../Button";
 import UserProfileArea from "../profile/UserProfileArea";
-import { DriverUser } from "@/types/card";
+import { DriverUser, DriverProfileData } from "@/types/card";
 import { isDriverUser } from "@/utils/type-guards";
 import { MoveTypeMap } from "@/types/moveTypes";
 
@@ -18,7 +18,7 @@ export default function OrderCard({ user, request, quotation }: CommonCardProps)
   const driverUser = user as DriverUser;
   const profileData = driverUser.profile;
   const { nickname, oneLiner, rating, confirmedCount, driverServiceTypes, ...restProfileData } =
-    profileData;
+    profileData as DriverProfileData;
   const price = quotation?.price;
   const tags = request?.serviceType;
 

--- a/src/components/ui/card/ProfileCard.tsx
+++ b/src/components/ui/card/ProfileCard.tsx
@@ -17,12 +17,12 @@ export default function ProfileCard({ user }: CommonCardProps) {
   const profileData = driverUser.profile;
   const movingInfo: MovingInfo = useMemo(() => {
     const info: MovingInfo = {
-      serviceTypes: profileData.driverServiceTypes?.map((service) => MoveTypeMap[service].content),
-      serviceAreas: profileData.driverServiceAreas?.map((areaKey) => AreaMap[areaKey as AreaType]),
-      reviewCount: profileData.reviewCount,
-      rating: profileData.rating,
-      careerYears: profileData.careerYears,
-      confirmedCount: profileData.confirmedCount,
+      serviceTypes: profileData?.driverServiceTypes?.map((service) => MoveTypeMap[service].content),
+      serviceAreas: profileData?.driverServiceAreas?.map((areaKey) => AreaMap[areaKey as AreaType]),
+      reviewCount: profileData?.reviewCount,
+      rating: profileData?.rating,
+      careerYears: profileData?.careerYears,
+      confirmedCount: profileData?.confirmedCount,
     };
 
     return info;
@@ -45,7 +45,7 @@ export default function ProfileCard({ user }: CommonCardProps) {
         <div className="hidden lg:flex lg:flex-col lg:gap-4">
           <div className="flex max-w-1/2 flex-col gap-2">
             {user.name && <CardText className="text-2xl">{user.name}</CardText>}
-            {profileData.oneLiner && (
+            {profileData?.oneLiner && (
               <CardText className="text-gray-600">{profileData.oneLiner}</CardText>
             )}
           </div>

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -19,21 +19,27 @@ export interface DriverProfileData {
 }
 export interface ConsumerProfileData {
   consumerId: string;
-  name: string;
+  image?: string;
+  serviceType?: ServerMoveType[];
+  areas?: AreaType;
 }
 
 export interface DriverUser {
   userId: string;
   name: string;
   role: "DRIVER";
-  profile: DriverProfileData;
+  email?: string;
+  phoneNumber?: string;
+  profile: DriverProfileData | null;
 }
 
 export interface ConsumerUser {
   userId: string;
   name: string;
   role: "CONSUMER";
-  profile?: ConsumerProfileData;
+  email?: string;
+  phoneNumber?: string;
+  profile?: ConsumerProfileData | null;
 }
 
 // 최종 유저 데이터 타입


### PR DESCRIPTION
이슈 번호 : #72 

작업 요약 : 일반유저 프로필 등록 컴포넌트 작업 완료(마크업 및 반응형)

작업내역
- mypage/profile 로 프로필 페이지 접근하면, user.role에 따라 폼 컴포넌트 다를 수 있게 작업하고자 함
<img width="2539" height="1351" alt="image" src="https://github.com/user-attachments/assets/06639f66-fb81-4ca8-8d8a-be4f0e7b8c8d" />

공유 내용
- 기존 작업된 mypage/profileEdit/[id] 경로는 mypage/profile/edit으로 변경