### PR TITLE
feat:기사님 프로필 수정 페이지 마크업 #78

### DIFF
--- a/src/app/mypage/profile/components/DriverProfileForm.tsx
+++ b/src/app/mypage/profile/components/DriverProfileForm.tsx
@@ -19,16 +19,22 @@ type DriverFormState = Partial<DriverProfileData> & {
   description?: string;
 };
 
-const hasField = (obj: any, field: string): boolean => {
-  return obj && typeof obj === "object" && field in obj;
+const hasField = (obj: unknown, field: string): obj is Record<string, unknown> => {
+  return obj !== null && typeof obj === "object" && field in obj;
 };
 
-const getStringField = (obj: any, field: string): string => {
-  return hasField(obj, field) && typeof obj[field] === "string" ? obj[field] : "";
+const getStringField = (obj: unknown, field: string): string => {
+  if (hasField(obj, field) && typeof obj[field] === "string") {
+    return obj[field] as string;
+  }
+  return "";
 };
 
-const getArrayField = (obj: any, field: string): string[] => {
-  return hasField(obj, field) && Array.isArray(obj[field]) ? obj[field] : [];
+const getArrayField = (obj: unknown, field: string): string[] => {
+  if (hasField(obj, field) && Array.isArray(obj[field])) {
+    return obj[field] as string[];
+  }
+  return [];
 };
 
 export const REGIONS = [
@@ -94,7 +100,7 @@ export default function DriverProfileForm({ initialData, userId }: DriverFormPro
     }
   }, [initialData]);
 
-  const updateField = (key: keyof DriverFormState, value: any) => {
+  const updateField = <K extends keyof DriverFormState>(key: K, value: DriverFormState[K]) => {
     setFormData((prev) => ({ ...prev, [key]: value }));
   };
 

--- a/src/app/mypage/profile/components/DriverProfileForm.tsx
+++ b/src/app/mypage/profile/components/DriverProfileForm.tsx
@@ -1,41 +1,134 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DriverProfileData } from "@/types/card";
-import InputArea from "./InputArea";
+import InputArea from "../../basicEdit/[id]/components/InputArea";
 import ImageInputArea from "./ImageInputArea";
 import TagForm from "./TagForm";
 import Button from "@/components/ui/Button";
 
 interface DriverFormProps {
-  initialData: DriverProfileData;
+  initialData: DriverProfileData | null;
   userId: string;
 }
 
+type DriverFormState = Partial<DriverProfileData> & {
+  services?: string[];
+  regions?: string[];
+  oneLiner?: string;
+  description?: string;
+};
+
+const hasField = (obj: any, field: string): boolean => {
+  return obj && typeof obj === "object" && field in obj;
+};
+
+const getStringField = (obj: any, field: string): string => {
+  return hasField(obj, field) && typeof obj[field] === "string" ? obj[field] : "";
+};
+
+const getArrayField = (obj: any, field: string): string[] => {
+  return hasField(obj, field) && Array.isArray(obj[field]) ? obj[field] : [];
+};
+
+export const REGIONS = [
+  "서울",
+  "경기",
+  "인천",
+  "강원",
+  "충북",
+  "충남",
+  "세종",
+  "대전",
+  "전북",
+  "전남",
+  "광주",
+  "경북",
+  "경남",
+  "대구",
+  "울산",
+  "부산",
+  "제주",
+];
+export type Region = (typeof REGIONS)[number];
+
 export default function DriverProfileForm({ initialData, userId }: DriverFormProps) {
-  const regions = [
-    "서울",
-    "경기",
-    "인천",
-    "강원",
-    "충북",
-    "충남",
-    "세종",
-    "대전",
-    "전북",
-    "전남",
-    "광주",
-    "경북",
-    "경남",
-    "대구",
-    "울산",
-    "부산",
-    "제주",
-  ];
   const [selectedServices, setSelectedServices] = useState<string[]>([]);
-  const [formData, setFormData] = useState<DriverProfileData>(initialData);
+  const [selectedRegions, setSelectedRegions] = useState<string[]>([]);
+  const [formData, setFormData] = useState<DriverFormState>({});
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
+  const [showNickname, setShowNicknma] = useState(false);
+
+  const isEditMode = initialData !== null;
+
+  useEffect(() => {
+    if (initialData) {
+      setFormData({
+        ...initialData,
+        oneLiner: getStringField(initialData, "oneLiner"),
+        description: getStringField(initialData, "description"),
+        services: [],
+        regions: [],
+      });
+
+      const services = getArrayField(initialData, "services");
+      const regions = getArrayField(initialData, "regions");
+
+      if (services.length > 0) {
+        setSelectedServices(services);
+      }
+      if (regions.length > 0) {
+        setSelectedRegions(regions);
+      }
+    } else {
+      // 등록 모드: 빈 폼
+      setFormData({
+        nickname: "",
+        careerYears: 0,
+        oneLiner: "",
+        description: "",
+        services: [],
+        regions: [],
+      });
+    }
+  }, [initialData]);
+
+  const updateField = (key: keyof DriverFormState, value: any) => {
+    setFormData((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = () => {
+    if (isEditMode) {
+      // 수정 API 호출
+      console.log("수정 데이터:", formData);
+      // TODO: 수정 API 연결
+    } else {
+      // 등록 API 호출
+      console.log("등록 데이터:", formData);
+      // TODO: 등록 API 연결
+    }
+  };
+
+  const handleCancel = () => {
+    if (isEditMode && initialData) {
+      // 원래 데이터로 되돌리기
+      setFormData({
+        ...initialData,
+        oneLiner: getStringField(initialData, "oneLiner"),
+        description: getStringField(initialData, "description"),
+        services: [],
+        regions: [],
+      });
+
+      const services = getArrayField(initialData, "services");
+      const regions = getArrayField(initialData, "regions");
+
+      setSelectedServices(services);
+      setSelectedRegions(regions);
+    }
+    // TODO: 페이지 이동 또는 모달 닫기
+  };
 
   return (
     <>
@@ -44,28 +137,49 @@ export default function DriverProfileForm({ initialData, userId }: DriverFormPro
           <div className="flex w-full flex-col lg:flex-row lg:gap-15">
             <div className="flex w-full flex-col gap-4 lg:w-1/2">
               <div className="w-full">
-                <div className="flex w-full">
+                <div className="mb-6 flex w-full flex-col">
                   <p className="w-full border-b border-[#F2F2F2] pb-4 text-[18px] leading-[26px] font-bold text-[#1F1F1F]">
-                    프로필수정
+                    {isEditMode ? "기사님 프로필 수정" : "기사님 프로필 등록"}
                   </p>
+                  <span>{isEditMode ? "" : "추가 정보를 입력하여 회원가입을 완료해주세요."}</span>
                 </div>
-                <InputArea label="별명" />
+
                 <ImageInputArea />
-                <InputArea label="경력" />
-                <InputArea label="한 줄 소개" />
+                <InputArea
+                  label="별명"
+                  value={formData.nickname || ""}
+                  onChange={(value) => updateField("nickname", value)}
+                />
+                <InputArea
+                  label="경력"
+                  value={formData.careerYears ? String(formData.careerYears) : ""}
+                  onChange={(value) => updateField("careerYears", Number(value) || 0)}
+                  inputType="number"
+                />
+                <InputArea
+                  label="한 줄 소개"
+                  value={formData.oneLiner || ""}
+                  onChange={(value) => updateField("oneLiner", value)}
+                />
 
                 <div className="mt-4 lg:hidden">
                   <TagForm
                     Tags={["소형이사", "가정이사", "사무실이사"]}
-                    label="상세설명"
+                    label="제공 서비스"
                     colType="flex"
                     selectedTags={selectedServices}
-                    setSelectedTags={setSelectedServices}
+                    setSelectedTags={(tags) => {
+                      setSelectedServices(tags);
+                      updateField("services", tags);
+                    }}
                   />
                   <TagForm
-                    selectedTags={selectedServices}
-                    setSelectedTags={setSelectedServices}
-                    Tags={regions}
+                    selectedTags={selectedRegions}
+                    setSelectedTags={(tags) => {
+                      setSelectedRegions(tags);
+                      updateField("regions", tags);
+                    }}
+                    Tags={REGIONS}
                     label="가능구역"
                     colType="grid"
                   />
@@ -73,22 +187,33 @@ export default function DriverProfileForm({ initialData, userId }: DriverFormPro
               </div>
 
               <div className="mt-4 w-full">
-                <InputArea label="상세 설명" type="textArea" borderOption="not" />
+                <InputArea
+                  label="상세 설명"
+                  type="textArea"
+                  value={formData.description || ""}
+                  onChange={(value) => updateField("description", value)}
+                />
               </div>
             </div>
 
             <div className="hidden gap-4 lg:flex lg:w-1/2 lg:flex-col">
               <TagForm
                 selectedTags={selectedServices}
-                setSelectedTags={setSelectedServices}
+                setSelectedTags={(tags) => {
+                  setSelectedServices(tags);
+                  updateField("services", tags);
+                }}
                 Tags={["소형이사", "가정이사", "사무실이사"]}
                 label="상세설명"
                 colType="flex"
               />
               <TagForm
-                selectedTags={selectedServices}
-                setSelectedTags={setSelectedServices}
-                Tags={regions}
+                selectedTags={selectedRegions}
+                setSelectedTags={(tags) => {
+                  setSelectedRegions(tags);
+                  updateField("regions", tags);
+                }}
+                Tags={REGIONS}
                 label="가능구역"
                 colType="grid"
               />
@@ -96,8 +221,21 @@ export default function DriverProfileForm({ initialData, userId }: DriverFormPro
           </div>
 
           <div className="mt-4 flex w-full flex-col gap-3 lg:w-full lg:flex-row">
-            <Button className="w-full lg:order-2" text="수정하기" />
-            <Button className="w-full lg:order-1" variant="secondary" text="취소" />
+            <Button
+              className="w-full lg:order-2"
+              text={isEditMode ? "수정하기" : "시작하기"}
+              disabled={loading}
+              onClick={handleSubmit}
+            />
+            {isEditMode && (
+              <Button
+                className="w-full lg:order-1"
+                variant="secondary"
+                text="취소"
+                disabled={loading}
+                onClick={handleCancel}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/src/app/mypage/profile/page.tsx
+++ b/src/app/mypage/profile/page.tsx
@@ -11,9 +11,10 @@ import ConsumerProfileForm from "./components/ConsumerProfileForm";
 import DriverProfileForm from "./components/DriverProfileForm";
 
 async function getCurrentUser(): Promise<UserData | null> {
-  const isDriver = false; // 테스트를 위해 Driver/Consumer를 전환 가능
+  const isDriver = true; // 테스트를 위해 Driver/Consumer를 전환 가능
 
   if (isDriver) {
+    // 스키마에 맞춘 목데이터 (수정 모드 테스트용)
     const driverProfile: DriverProfileData = {
       driverId: "d-id-123",
       nickname: "베스트 드라이버",
@@ -23,7 +24,16 @@ async function getCurrentUser(): Promise<UserData | null> {
       careerYears: 5,
       confirmedCount: 200,
       likes: {},
-    };
+      // 추가 필드들 (as any로 타입 체크 우회)
+      oneLiner: "안전하고 빠른 이사를 약속드립니다",
+      description:
+        "10년 경력의 전문 이사 기사입니다. 고객만족을 최우선으로 생각하며, 안전하고 신속한 서비스를 제공합니다.",
+      services: ["소형이사", "가정이사"],
+      regions: ["서울", "경기", "인천"],
+    } as DriverProfileData;
+
+    // 등록 모드 테스트하려면 아래 주석 해제하고 위 코드 주석처리
+    // const driverProfile: DriverProfileData | null = null;
 
     const driverUser: DriverUser = {
       userId: "d123",

--- a/src/app/test/driverprofileTest/page.tsx
+++ b/src/app/test/driverprofileTest/page.tsx
@@ -1,5 +1,0 @@
-import DriverProfileForm from "@/app/mypage/components/DriverProfileForm";
-
-export default function driverprofileTest() {
-  return <DriverProfileForm />;
-}

--- a/src/utils/constant/error.ts
+++ b/src/utils/constant/error.ts
@@ -19,7 +19,7 @@ export const errors = {
   loginError: "존재하지 않는 이메일, 혹은 비밀번호입니다.",
 } as const;
 
-// driverProfileForm 관련 error
+// ProfileForm 관련 error
 export const error = {
   nickNameEmpty: "별명을 입력해주세요.",
   histotyInvalid: "숫자만 입력해주세요.",


### PR DESCRIPTION
## 작업 내용

- [x]  `DriverprofileForm.tsx`파일 작성(기본 페이지 마크업, mock데이터로 확인하기 쉽게 수정부터)
    - 등록, 수정 페이지 레이아웃은 동일하게 진행
    - 수정 페이지 → `취소`버튼 생성, profile 값 받아와서 Input 내부에 자동 적용
- [x]  기사님 프로필 수정
    - 시작하기 버튼 → 수정하기 버튼 변환
    - 취소 버튼 생성(수정하기에서만)