### PR TITLE
[FIX] rewrite 하드코딩 수정 및 환경별 백엔드 분기

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,8 @@
 import type { NextConfig } from "next";
 
+const isProd = process.env.NODE_ENV === "production";
+const BACKEND_ORIGIN = isProd ? process.env.NEXT_PUBLIC_API_URL : "http://localhost:4000";
+
 const nextConfig: NextConfig = {
   /* config options here */
   // 외부 이미지로 기본 프로필 이외의 이미지 출력 테스트용
@@ -10,7 +13,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/api/:path*", // 프론트에서 호출할 경로
-        destination: "http://localhost:4000/:path*", // 실제 백엔드 서버
+        destination: `${BACKEND_ORIGIN}/:path*`, // 실제 백엔드 서버
       },
     ];
   },

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { useAuthStore } from "@/store/authStore";
 
 const apiClient = axios.create({
-  baseURL: process.env.NODE_ENV === "development" ? "/api" : process.env.NEXT_PUBLIC_API_URL,
+  baseURL: "/api",
   withCredentials: true,
   headers: { "Content-Type": "application/json" },
   // 304 Not Modified 는 캐시 사용 신호이므로 reject 되지 않도록 허용


### PR DESCRIPTION
#️⃣ 연관된 이슈
#94 

## #️⃣ 변경 내용
**next.config.js**
- 기존 destination: "http://localhost:4000/:path*" 하드코딩 제거
- NODE_ENV 및 NEXT_PUBLIC_API_URL 기반으로 dev/prod 분기
- dev → http://localhost:4000
- prod → EC2 주소(NEXT_PUBLIC_API_URL)
- apiClient : baseURL을 /api로 통일하여 프록시 경로 일원화

## #️⃣ 주요 효과
- 배포 환경에서 API 요청이 EC2로 정상 프록시
- 로컬/배포 모두 동일한 요청 경로(/api/...) 유지
- 브라우저 Network 탭 기준 /api 요청 표시 그대로 유지

## #️⃣ 테스트 결과
- 로컬에서 /api/auth/signin → localhost:4000/auth/signin 정상 프록시