### PR TITLE
[FIX] API 호출 통일 및 인터셉터 refresh 로직 수정 #94

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,5 +1,5 @@
-import axios from "axios";
 import { useAuthStore } from "@/store/authStore";
+import axios from "axios";
 
 const apiClient = axios.create({
   baseURL: "/api",
@@ -36,11 +36,7 @@ apiClient.interceptors.response.use(
         console.log("[인터셉터] 401 발생 → refresh 시도");
 
         // refresh는 토큰 갱신만 (user 데이터 건드리지 않음)
-        await axios.post(
-          (process.env.NEXT_PUBLIC_API_URL ?? "/api") + "/auth/refresh",
-          {},
-          { withCredentials: true }
-        );
+        await axios.post("/api" + "/auth/refresh", {}, { withCredentials: true });
 
         console.log("[인터셉터] refresh 성공 → 원래 요청 재시도");
 

--- a/src/utils/hook/signup/api.tsx
+++ b/src/utils/hook/signup/api.tsx
@@ -1,12 +1,5 @@
-import axios from "axios";
+import apiClient from "@/lib/apiClient";
 import { useMutation } from "@tanstack/react-query";
-
-const host = "/api";
-const api = axios.create({
-  baseURL: host,
-  headers: { "Content-Type": "application/json" },
-  withCredentials: true,
-});
 
 export type RoleType = "CONSUMER" | "DRIVER";
 
@@ -30,7 +23,7 @@ export interface UserData {
 export function useSignup() {
   return useMutation<UserData, Error, SignUpDTO>({
     mutationFn: async (data: SignUpDTO) => {
-      const res = await api.post<UserData>("/auth/signup", data);
+      const res = await apiClient.post<UserData>("/auth/signup", data);
       return res.data;
     },
     onError: (err) => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#94

## #️⃣ 변경 내용
- apiClient 통합
- 기존에 개별 axios/fetch로 직접 백엔드(EC2) 호출하던 부분을 전부 apiClient로 변경
- 모든 요청이 /api/... 경로로 프록시를 타도록 수정

응답 인터셉터 개선
- refresh 요청 시 인터셉터 무한루프 방지 위해 apiClient 대신 기본 axios 사용
- refresh 경로를 /api/auth/refresh 로 고정 → Next.js 리라이트가 환경에 따라 백엔드로 프록시

## #️⃣ 주요 효과
- 프론트 전역에서 API 요청 경로가 /api로 통일
- 배포 환경에서 /api 요청이 Vercel → EC2로 정상 프록시
- 로컬 및 배포 환경 모두 동일한 동작 보장

## #️⃣ 테스트 결과
- /api/auth/signin 요청 시 200 OK
- 브라우저 Network 탭 기준 요청 URL /api/... 로 일관 유지