### PR TITLE
fix: 기사 로그인 후 프로필 미등록시 리다이렉트 및 기본 이미지 표시 개선

### DIFF
--- a/src/app/login/components/LoginForm.tsx
+++ b/src/app/login/components/LoginForm.tsx
@@ -4,6 +4,7 @@ import Button from "@/components/ui/Button";
 import { useLogin } from "@/utils/hook/auth/useLogin";
 import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/store/authStore";
+import { getUserProfile } from "@/utils/hook/profile/profile";
 
 type LoginFormProps = {
   role: "DRIVER" | "CONSUMER";
@@ -44,8 +45,29 @@ export default function LoginForm({ role }: LoginFormProps) {
     login(
       { email, password, role },
       {
-        onSuccess: () => {
+        onSuccess: async () => {
           console.log("로그인성공");
+
+          // 기사 계정인 경우 프로필 여부 확인
+          if (role === "DRIVER") {
+            try {
+              const profile = await getUserProfile();
+
+              // 프로필이 없으면 프로필 등록 페이지로
+              if (!profile || !profile.profile) {
+                console.log("[LoginForm] 프로필 미등록 - 프로필 등록 페이지로 이동");
+                router.push("/mypage/profile");
+                return;
+              }
+            } catch (error) {
+              // 프로필 조회 실패 시 (500 에러 등) 프로필 등록 페이지로
+              console.log("[LoginForm] 프로필 조회 실패 - 프로필 등록 페이지로 이동");
+              router.push("/mypage/profile");
+              return;
+            }
+          }
+
+          // 일반 고객이거나 프로필이 있는 기사는 랜딩 페이지로
           router.push("/landing");
         },
         onError: () => {

--- a/src/components/ui/profile/UserProfileArea.tsx
+++ b/src/components/ui/profile/UserProfileArea.tsx
@@ -62,7 +62,7 @@ export default function UserProfileArea({
 
   return (
     <div className={`relative flex items-center gap-3 ${className ?? ""}`}>
-      {driverProfile?.image && <ProfileViewer initialImageUrl={driverProfile.image} />}
+      {isDriver && <ProfileViewer initialImageUrl={driverProfile?.image || ""} />}
 
       <div className="flex flex-col gap-1 lg:gap-2">
         {isVisible("name") && (


### PR DESCRIPTION
---

# 🔀 기사 로그인 후 프로필 미등록 시 리다이렉트 및 기본 이미지 표시 개선

## 🎯 작업 개요
기사 계정 로그인 후 프로필 여부를 확인하여 적절한 페이지로 리다이렉트하고, 프로필 이미지가 없을 때 기본 이미지가 표시되도록 개선

## 📝 변경사항

### ✨ 새로운 기능

**로그인 후 프로필 여부에 따른 리다이렉트 분기**
- 기사 계정 로그인 시 프로필 조회
- 프로필 미등록 시 → `/mypage/profile` (프로필 등록 페이지)
- 프로필 등록 완료 시 → `/landing` (랜딩 페이지)
- 고객 계정은 항상 → `/landing`

### 🐛 버그 수정

**프로필 이미지 없을 때 기본 이미지 미표시 문제 해결**
- 조건부 렌더링 로직 개선 (`driverProfile?.image &&` → `isDriver &&`)
- 이미지가 없어도 `ProfileViewer` 컴포넌트가 렌더링되어 기본 이미지 표시

## 📂 변경된 파일

### 수정된 파일
```
src/app/login/components/LoginForm.tsx
src/components/ui/profile/UserProfileArea.tsx
```

## 🔧 상세 변경 내역

### 1. LoginForm.tsx

**변경 전:**
```tsx
onSuccess: () => {
  console.log("로그인성공");
  router.push("/landing");
}
```

**변경 후:**
```tsx
onSuccess: async () => {
  console.log("로그인성공");

  // 기사 계정인 경우 프로필 여부 확인
  if (role === "DRIVER") {
    try {
      const profile = await getUserProfile();
      
      // 프로필이 없으면 프로필 등록 페이지로
      if (!profile || !profile.profile) {
        router.push("/mypage/profile");
        return;
      }
    } catch (error) {
      // 프로필 조회 실패 시도 프로필 등록 페이지로
      router.push("/mypage/profile");
      return;
    }
  }
  
  // 일반 고객이거나 프로필이 있는 기사는 랜딩 페이지로
  router.push("/landing");
}
```

### 2. UserProfileArea.tsx

**변경 전:**
```tsx
{driverProfile?.image && <ProfileViewer initialImageUrl={driverProfile.image} />}
```

**변경 후:**
```tsx
{isDriver && <ProfileViewer initialImageUrl={driverProfile?.image || ""} />}
```

**개선 사항:**
- `ProfileViewer` 컴포넌트는 내부적으로 `initialImageUrl || getRandomProfileImage()` 로직을 가지고 있음
- 이미지가 없어도 항상 렌더링되어 기본 이미지가 표시됨

## 🧪 테스트 방법

### 1. 프로필 미등록 기사 로그인 테스트
1. 프로필이 없는 기사 계정으로 로그인
2. ✅ `/mypage/profile`로 자동 이동 확인
3. 프로필 등록 완료
4. 다시 로그인 시 ✅ `/landing`으로 이동 확인

### 2. 기본 이미지 표시 테스트
1. 이미지를 등록하지 않은 기사 프로필 조회
2. ✅ `/mypage`에서 기본 프로필 이미지가 표시되는지 확인
3. ✅ 프로필 카드에 기본 이미지가 표시되는지 확인

### 3. 고객 로그인 테스트
1. 고객 계정으로 로그인
2. ✅ `/landing`으로 이동 확인

## 📌 관련 이슈

- 프로필 미등록 기사 로그인 시 `/landing` 대신 프로필 등록 페이지로 이동 필요
- 프로필 이미지 없을 때 기본 이미지 미표시 문제

## 🔗 연관 작업

이전 PR: #102  - 기사 프로필 등록 API 연결

## ✅ 체크리스트

- [x] 타입스크립트 에러 없음
- [x] 로컬 환경에서 테스트 완료
- [x] 프로필 미등록 → 등록 → 재로그인 플로우 테스트 완료
- [x] 기본 이미지 표시 확인
- [x] 코드 리뷰 준비 완료

---