### PR TITLE
feat: 받은 요청 API 연동 1차 작업 완료 #106

### DIFF
--- a/src/app/request/components/SearchBar.tsx
+++ b/src/app/request/components/SearchBar.tsx
@@ -3,20 +3,18 @@
 import React, { useState } from "react";
 import Input from "@/components/ui/Input";
 
-export default function SearchBar() {
-  const [keyword, setKeyword] = useState("");
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+}
 
-  const handleSearchChange = (value: string) => {
-    setKeyword(value);
-  };
-
+export default function SearchBar({ value, onChange }: SearchBarProps) {
   return (
-    // ...
     <Input
       type="search"
-      value={keyword}
+      value={value}
       placeholder="어떤 고객님을 찾고 계세요?"
-      onChange={handleSearchChange}
+      onChange={onChange}
       className="w-full max-w-full"
       icon="left"
     />

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -1,22 +1,72 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo, useEffect } from "react";
 import Image from "next/image";
 import RequestCard from "@/components/ui/card/RequestCard";
 import SearchBar from "./components/SearchBar";
 import { SortTechFilter, ResponsiveMoveAndFilter } from "@/components/ui/Filters/Filters";
-import { CommonCardProps } from "@/components/ui/card/BaseCard";
 import FilterContainer from "@/components/ui/Modal/FilterContainer";
 import NodataArea from "@/components/ui/nodata/NodataArea";
+import { useReceivedRequests, useFilteredRequests } from "@/hooks/useReceivedRequests";
+import { MoveType } from "@/types/moveTypes";
+import { ReceivedRequestFilter } from "@/types/receivedRequest";
 
 export default function RequestPage() {
   const [sortTech, setSortTech] = useState("이사 빠른순");
-  const [moveTypeSelected, setMoveTypeSelected] = useState<string[]>([]);
+  const [moveTypeSelected, setMoveTypeSelected] = useState<MoveType[]>([]);
   const [filterTypeSelected, setFilterTypeSelected] = useState<string[]>([]);
   const [filterOpen, setFilterOpen] = useState(false);
+  const [searchKeyword, setSearchKeyword] = useState("");
+
+  const { data: baseData, isLoading, isError } = useReceivedRequests();
+  const { mutate: filterRequests, data: filteredData, isPending } = useFilteredRequests();
+
+  const responseData = filteredData ?? baseData ?? [];
+
+  const filterCounts = useMemo(() => {
+    if (!Array.isArray(baseData)) {
+      return { moveType: {}, invited: 0, region: 0 };
+    }
+
+    const counts = {
+      moveType: {} as Record<MoveType, number>,
+      invited: 0,
+      region: 0,
+    };
+
+    for (const item of baseData ?? []) {
+      // moveType 카운트
+      const type = item.serviceType as MoveType;
+      counts.moveType[type] = (counts.moveType[type] || 0) + 1;
+
+      // 지정 요청 카운트
+      if (item.isInvited) counts.invited += 1;
+
+      // 지역 카운트 (departure 기준)
+      if (item.departureAddress) counts.region += 1;
+    }
+
+    return counts;
+  }, [baseData]);
+
+  const handleFilterApply = () => {
+    const filter: ReceivedRequestFilter = {
+      serviceTypes: moveTypeSelected.length ? moveTypeSelected : undefined,
+      isInvited: filterTypeSelected.includes("invited") ? true : undefined,
+      consumerName: searchKeyword || undefined,
+      sortByMoveAt: sortTech === "이사 빠른순" ? "asc" : undefined,
+      sortByCreatedAt: sortTech === "요청일 빠른순" ? "asc" : undefined,
+    };
+    console.log("📤 필터 요청 payload:", filter);
+    filterRequests(filter);
+  };
+
+  // 1. toggle에서는 상태만 갱신
   const toggleMoveType = (value: string) => {
     setMoveTypeSelected((prev) =>
-      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]
+      prev.includes(value as MoveType)
+        ? prev.filter((v) => v !== (value as MoveType))
+        : [...prev, value as MoveType]
     );
   };
 
@@ -26,58 +76,13 @@ export default function RequestPage() {
     );
   };
 
-  interface ServerData {
-    totalCount: number;
-    data: CommonCardProps[];
-  }
+  // 2. 최신 상태 기반 자동 필터링 (useEffect로 변경 감지)
+  useEffect(() => {
+    handleFilterApply();
+  }, [moveTypeSelected, filterTypeSelected, sortTech, searchKeyword]);
 
-  const responseData: ServerData | null = null;
-  // const responseData: ServerData | null = {
-  //   totalCount: 2,
-  //   data: [
-  //     {
-  //       user: {
-  //         userId: "user-consumer-001",
-  //         name: "김철수",
-  //         role: "CONSUMER",
-  //       },
-  //       request: {
-  //         requestId: "req-789",
-  //         serviceType: ["SMALL_MOVE"],
-  //         departureAddress: "인천시 남동구",
-  //         arrivalAddress: "경기도 고양시",
-  //         requestStatement: "PENDING",
-  //         moveAt: "2024-07-01",
-  //         createdAt: "2025-09-25",
-  //       },
-  //       quotation: {
-  //         quotationId: "q-123",
-  //         departureAddress: "서울시 강남구",
-  //         arrivalAddress: "경기도 성남시",
-  //         price: 180000,
-  //         moveAt: "2025-10-15",
-  //         createdAt: "2025-09-25",
-  //         quotationStatement: "ACCEPTED",
-  //       },
-  //     },
-  //     {
-  //       user: {
-  //         userId: "user-consumer-002",
-  //         name: "홍길동",
-  //         role: "CONSUMER",
-  //       },
-  //       request: {
-  //         requestId: "req-780",
-  //         serviceType: ["SMALL_MOVE"],
-  //         departureAddress: "서울시 강남구",
-  //         arrivalAddress: "경기도 성남시",
-  //         requestStatement: "PENDING",
-  //         moveAt: "2025-10-15",
-  //         createdAt: "2025-09-25",
-  //       },
-  //     },
-  //   ],
-  // };
+  if (isLoading) return <p>로딩 중...</p>;
+  if (isError) return <p>데이터를 불러오는 중 오류가 발생했습니다.</p>;
 
   return (
     <>
@@ -92,14 +97,13 @@ export default function RequestPage() {
               onToggleMove={toggleMoveType}
               filterSelected={filterTypeSelected}
               onToggleFilter={toggleFilterType}
+              filterCounts={filterCounts}
             />
           </div>
           <div className="flex flex-1 flex-col gap-3 md:gap-4 lg:gap-8">
-            <SearchBar />
+            <SearchBar value={searchKeyword} onChange={(value) => setSearchKeyword(value)} />
             <div className="flex items-center justify-between py-1">
-              <p className="text-sm lg:text-base">
-                전체 {responseData ? (responseData as ServerData).totalCount : 0}건
-              </p>
+              <p className="text-sm lg:text-base">전체 {responseData.length}건</p>
               <div className="flex items-center gap-2">
                 <SortTechFilter selected={sortTech} onChange={setSortTech} />
                 <button
@@ -112,13 +116,26 @@ export default function RequestPage() {
               </div>
             </div>
             <div className="flex flex-col gap-6 md:gap-8 lg:gap-12">
-              {responseData && (responseData as ServerData).data.length > 0 ? (
-                (responseData as ServerData).data.map((cardData, index) => (
+              {responseData.length > 0 ? (
+                responseData.map((cardData, index) => (
                   <RequestCard
-                    key={cardData.request?.requestId || index}
-                    user={cardData.user}
-                    request={cardData.request}
-                    quotation={cardData.quotation}
+                    key={cardData.id || index}
+                    user={{
+                      userId: cardData.id,
+                      name: cardData.consumerName,
+                      role: "CONSUMER",
+                      email: "",
+                      phoneNumber: "",
+                    }}
+                    request={{
+                      requestId: cardData.id,
+                      serviceType: [cardData.serviceType],
+                      departureAddress: cardData.departureAddress,
+                      arrivalAddress: cardData.arrivalAddress,
+                      requestStatement: "PENDING",
+                      moveAt: cardData.moveAt,
+                      createdAt: cardData.createdAt,
+                    }}
                   />
                 ))
               ) : (

--- a/src/components/ui/Filters/Filters.tsx
+++ b/src/components/ui/Filters/Filters.tsx
@@ -60,23 +60,42 @@ export function ResponsiveMoveAndFilter(props: {
   onToggleMove: (v: string) => void;
   filterSelected: string[];
   onToggleFilter: (v: string) => void;
+  filterCounts?: {
+    moveType: Record<string, number>;
+    invited: number;
+    region: number;
+  };
 }) {
+  const { moveTypeSelected, onToggleMove, filterSelected, onToggleFilter, filterCounts } = props;
+
+  const moveOptions = MOVE_TYPE_OPTIONS.map((opt) => ({
+    ...opt,
+    label: `${opt.label.split(" ")[0]} (${filterCounts?.moveType?.[opt.value] ?? 0})`,
+  }));
+
+  const filterOptions = CHECK_FILTER_OPTIONS.map((opt) => {
+    const count =
+      opt.value === "invited" ? (filterCounts?.invited ?? 0) : (filterCounts?.region ?? 0);
+
+    const baseLabel = opt.label.replace(/\s*\(\d+\)/, "");
+    return { ...opt, label: `${baseLabel} (${count})` };
+  });
   return (
     <ResponsiveCheckFilter
       filters={[
         {
           key: "moveType",
           title: "이사 유형",
-          options: MOVE_TYPE_OPTIONS,
-          selected: props.moveTypeSelected,
-          onToggle: props.onToggleMove,
+          options: moveOptions,
+          selected: moveTypeSelected,
+          onToggle: onToggleMove,
         },
         {
           key: "filter",
           title: "필터",
-          options: CHECK_FILTER_OPTIONS,
-          selected: props.filterSelected,
-          onToggle: props.onToggleFilter,
+          options: filterOptions,
+          selected: filterSelected,
+          onToggle: onToggleFilter,
         },
       ]}
     />

--- a/src/components/ui/Filters/filterOptions.ts
+++ b/src/components/ui/Filters/filterOptions.ts
@@ -43,13 +43,13 @@ export const NOTIFICATION_OPTIONS = [
 
 // 체크 필터 - 이사 유형 옵션 (괄호 안 숫자 추후 API 작업 시 동적 처리 필요)
 export const MOVE_TYPE_OPTIONS = [
-  { label: "소형이사 (4)", value: "small" },
-  { label: "가정이사 (2)", value: "home" },
-  { label: "사무실이사 (10)", value: "office" },
+  { label: "소형이사", value: "SMALL_MOVE" },
+  { label: "가정이사", value: "HOME_MOVE" },
+  { label: "사무실이사", value: "OFFICE_MOVE" },
 ];
 
 //체크 필터 - 필터 옵션 (괄호 안 숫자 추후 API 작업 시 동적 처리 필요)
 export const CHECK_FILTER_OPTIONS = [
   { label: "서비스 가능 지역 (10)", value: "region" },
-  { label: "지정 견적 요청 (10)", value: "request" },
+  { label: "지정 견적 요청 (10)", value: "invited" },
 ];

--- a/src/components/ui/card/RequestCard.tsx
+++ b/src/components/ui/card/RequestCard.tsx
@@ -5,25 +5,26 @@ import Tag from "../Tag";
 import MovingInfoViewer, { MovingInfo } from "../profile/MovingInfoViewer";
 import Button from "../Button";
 import UserProfileArea from "../profile/UserProfileArea";
-import { MoveTypeMap } from "@/types/moveTypes";
+import { MoveTypeMap, ServerMoveType } from "@/types/moveTypes";
+import { formatDate, simplifyAreaName } from "@/utils/formatRequestData";
 
 export default function RequestCard({ user, request, quotation }: CommonCardProps) {
   const tags = request?.serviceType;
-  const requestedAt = request?.createdAt;
+  const requestedAt = request?.createdAt ? formatDate(request.createdAt) : "";
+  const moveDate = request?.moveAt ? formatDate(request.moveAt) : "";
   const movingInfo: MovingInfo = useMemo(() => {
-    const info: MovingInfo = {
-      departureAddress: request?.departureAddress,
-      arrivalAddress: request?.arrivalAddress,
-      moveAt: request?.moveAt,
+    return {
+      departureAddress: simplifyAreaName(request?.departureAddress ?? ""),
+      arrivalAddress: simplifyAreaName(request?.arrivalAddress ?? ""),
+      moveAt: moveDate,
     };
-
-    return info;
-  }, [request?.moveAt, request?.moveAt, request?.moveAt]);
+  }, [request?.departureAddress, request?.arrivalAddress, moveDate]);
 
   const NON_ACTIVE_STATUSES = ["CANCELLED", "REJECTED", "EXPIRED", "COMPLETED"];
   const isDimmed =
     NON_ACTIVE_STATUSES.includes(request?.requestStatement ?? "") ||
     NON_ACTIVE_STATUSES.includes(quotation?.quotationStatement ?? "");
+
   let stateMessage = "";
   if (request?.requestStatement === "CANCELLED" || quotation?.quotationStatement === "REJECTED") {
     stateMessage = "반려된 요청입니다";

--- a/src/hooks/useReceivedRequests.ts
+++ b/src/hooks/useReceivedRequests.ts
@@ -1,0 +1,17 @@
+import { useQuery, useMutation } from "@tanstack/react-query";
+import {
+  getReceivedRequests,
+  postFilteredRequests,
+} from "@/utils/hook/receivedRequest/receivedRequest";
+import { ReceivedRequestsResponse, ReceivedRequestFilter } from "@/types/receivedRequest";
+
+export const useReceivedRequests = () =>
+  useQuery<ReceivedRequestsResponse>({
+    queryKey: ["receivedRequests"],
+    queryFn: getReceivedRequests,
+  });
+
+export const useFilteredRequests = () =>
+  useMutation<ReceivedRequestsResponse, Error, ReceivedRequestFilter>({
+    mutationFn: postFilteredRequests,
+  });

--- a/src/types/receivedRequest.ts
+++ b/src/types/receivedRequest.ts
@@ -1,0 +1,26 @@
+import { AreaType } from "./areaTypes";
+import { MoveType } from "./moveTypes";
+
+export interface ReceivedRequest {
+  id: string;
+  consumerName: string;
+  moveAt: string;
+  departureAddress: string;
+  arrivalAddress: string;
+  serviceType: MoveType;
+  createdAt: string;
+  isInvited: boolean;
+}
+
+export type ReceivedRequestsResponse = ReceivedRequest[];
+
+export interface ReceivedRequestFilter {
+  serviceTypes?: MoveType[];
+  areas?: AreaType[];
+  isInvited?: boolean;
+  consumerName?: string;
+  moveAtFrom?: string;
+  moveAtTo?: string;
+  sortByMoveAt?: "asc" | "desc";
+  sortByCreatedAt?: "asc" | "desc";
+}

--- a/src/utils/formatRequestData.ts
+++ b/src/utils/formatRequestData.ts
@@ -1,0 +1,30 @@
+import { AreaMap } from "@/types/areaTypes";
+
+/**
+ * 날짜 포맷: YYYY-MM-DD
+ */
+export const formatDate = (dateString: string): string => {
+  if (!dateString) return "";
+  const date = new Date(dateString);
+  return date.toISOString().split("T")[0]; // ex) 2025-10-16
+};
+
+/**
+ * 주소 포맷: 앞 두 단어만 추출
+ * 예: "경기도 성남시 분당구 판교로" → "경기도 성남시"
+ */
+export const formatAddressShort = (address: string): string => {
+  if (!address) return "";
+  const words = address.split(" ");
+  return words.slice(0, 2).join(" ");
+};
+
+/**
+ * 지역명을 AreaMap 기반으로 단축
+ * 예: "서울특별시" → "서울", "경기도" → "경기"
+ */
+export const simplifyAreaName = (address: string): string => {
+  if (!address) return "";
+  const areaMatch = Object.entries(AreaMap).find(([key, value]) => address.includes(value));
+  return areaMatch ? areaMatch[1] : formatAddressShort(address);
+};

--- a/src/utils/hook/receivedRequest/receivedRequest.ts
+++ b/src/utils/hook/receivedRequest/receivedRequest.ts
@@ -1,0 +1,14 @@
+import apiClient from "@/lib/apiClient";
+import { ReceivedRequestFilter, ReceivedRequestsResponse } from "@/types/receivedRequest";
+
+export const getReceivedRequests = async (): Promise<ReceivedRequestsResponse> => {
+  const res = await apiClient.get("/requests/received");
+  return res.data.data;
+};
+
+export const postFilteredRequests = async (
+  filter: ReceivedRequestFilter
+): Promise<ReceivedRequestsResponse> => {
+  const res = await apiClient.post("/requests/received/search", filter);
+  return res.data.data;
+};


### PR DESCRIPTION
## 개요

- 기사 받은 요청 API 연동 작업 (1차)

## 관련 이슈

태그: #106  

## 구현

### 받은 요청 목록 조회
- GET으로 고객의 일반 견적 요청 리스트 조회 가능
- 카드의 형태로 견적 확인 가능
- 서비스 유형, 이사일, 출발지와 도착지, 요청일 확인 가능 
- 날짜와 지역은 실제 데이터보다 간소화하는 format을 거쳐 렌더링됨 (formatRequestData.ts)

### 받은 요청 목록 필터링
- POST로 받은 요청 목록 필터링 가능
- 필터 label 옆에 필터에 부합하는 요청 수 카운트

## TODO 
- 기사님 찾기 페이지 API 연동 후 이어서 작업 예정
- 지정 견적 요청 리스트 상위 노출되는지 확인
- 지정 견적 요청 tag 카드에 잘 반영되는지 확인
- 지정 견적 요청 필터링 되는지 확인
- sort 기능 및 드롭다운에 의한 페이지 위아래 움직임 수정
- 채팅방 개설 버튼 반영