### PR TITLE
feat: 고객 프로필 등록 및 UX 개선

### DIFF
--- a/src/app/login/components/LoginForm.tsx
+++ b/src/app/login/components/LoginForm.tsx
@@ -48,26 +48,24 @@ export default function LoginForm({ role }: LoginFormProps) {
         onSuccess: async () => {
           console.log("로그인성공");
 
-          // 기사 계정인 경우 프로필 여부 확인
-          if (role === "DRIVER") {
-            try {
-              const profile = await getUserProfile();
+          // 프로필 여부 확인 (기사/고객 모두)
+          try {
+            const profile = await getUserProfile();
 
-              // 프로필이 없으면 프로필 등록 페이지로
-              if (!profile || !profile.profile) {
-                console.log("[LoginForm] 프로필 미등록 - 프로필 등록 페이지로 이동");
-                router.push("/mypage/profile");
-                return;
-              }
-            } catch (error) {
-              // 프로필 조회 실패 시 (500 에러 등) 프로필 등록 페이지로
-              console.log("[LoginForm] 프로필 조회 실패 - 프로필 등록 페이지로 이동");
+            // 프로필이 없으면 프로필 등록 페이지로
+            if (!profile || !profile.profile) {
+              console.log("[LoginForm] 프로필 미등록 - 프로필 등록 페이지로 이동");
               router.push("/mypage/profile");
               return;
             }
+          } catch (error) {
+            // 프로필 조회 실패 시 (500 에러 등) 프로필 등록 페이지로
+            console.log("[LoginForm] 프로필 조회 실패 - 프로필 등록 페이지로 이동");
+            router.push("/mypage/profile");
+            return;
           }
 
-          // 일반 고객이거나 프로필이 있는 기사는 랜딩 페이지로
+          // 프로필이 있으면 랜딩 페이지로
           router.push("/landing");
         },
         onError: () => {

--- a/src/app/mypage/basicEdit/[id]/page.tsx
+++ b/src/app/mypage/basicEdit/[id]/page.tsx
@@ -4,16 +4,18 @@ import Header from "./components/Header";
 import InputArea from "./components/InputArea";
 import Button from "@/components/ui/Button";
 import { useRouter } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { updateBasicInfo } from "@/utils/hook/profile/profile";
 import { useUserStore } from "@/store/userStore";
 import { UpdateBasicInfoRequest } from "@/types/card";
 import { useProfileQuery } from "@/hooks/useProfileQuery";
+import { useAuthStore } from "@/store/authStore";
 
 export default function BasicEditPage() {
   const router = useRouter();
   const { setUser } = useUserStore();
   const { user, isLoading, error } = useProfileQuery();
+  const authUser = useAuthStore((s) => s.user);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
@@ -21,7 +23,17 @@ export default function BasicEditPage() {
   const [newPw, setNewPw] = useState("");
   const [confirmPw, setConfirmPw] = useState("");
   const [loading, setLoading] = useState(false);
+  const hasCheckedAccess = useRef(false);
   console.log("🚩 user data 확인:", user);
+
+  // DRIVER 계정만 접근 가능
+  useEffect(() => {
+    if (!hasCheckedAccess.current && authUser && authUser.role !== "DRIVER") {
+      hasCheckedAccess.current = true;
+      alert("기사 회원만 접근할 수 있습니다.");
+      router.push("/mypage/profile");
+    }
+  }, [authUser, router]);
 
   // user fetch 이후 input 초기값 반영
   useEffect(() => {
@@ -74,6 +86,17 @@ export default function BasicEditPage() {
       setLoading(false);
     }
   };
+
+  // 권한 체크 중
+  if (!authUser) {
+    return <div className="p-10 text-center">로딩 중...</div>;
+  }
+
+  // CONSUMER는 접근 불가 (리다이렉트 중)
+  if (authUser.role !== "DRIVER") {
+    return null;
+  }
+
   if (isLoading) return <div className="p-10 text-center">로딩 중...</div>;
   if (error || !user)
     return <div className="p-10 text-center">프로필 정보를 불러오지 못했습니다.</div>;

--- a/src/components/ui/nav/nav.tsx
+++ b/src/components/ui/nav/nav.tsx
@@ -9,6 +9,7 @@ import LogoMobile from "@/assets/icon/Logo-1.svg";
 import { useAuthStore } from "@/store/authStore";
 import { useUserStore } from "@/store/userStore";
 import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -25,6 +26,7 @@ export default function Nav({ option }: NavProps) {
   const clearUser = useAuthStore((s) => s.clearUser);
   const profileUser = useUserStore((s) => s.user);
   const clearProfileUser = useUserStore((s) => s.clearUser);
+  const queryClient = useQueryClient();
   const isLoggedIn = !!user;
 
   const displayName = user?.name ?? profileUser?.name ?? "임시유저";
@@ -44,6 +46,7 @@ export default function Nav({ option }: NavProps) {
     } finally {
       clearUser(); // zustand 상태 초기화
       clearProfileUser();
+      queryClient.clear(); // React Query 캐시 완전히 초기화
       router.push("/login");
     }
   };
@@ -92,6 +95,7 @@ export default function Nav({ option }: NavProps) {
                 width={32}
                 height={32}
                 alt="logo"
+                onClick={() => router.push("/landing")}
               />
               <Image
                 className="hidden cursor-pointer md:block"
@@ -99,6 +103,7 @@ export default function Nav({ option }: NavProps) {
                 width={100}
                 height={100}
                 alt="logo"
+                onClick={() => router.push("/landing")}
               />
             </>
           )}

--- a/src/hooks/useProfileQuery.ts
+++ b/src/hooks/useProfileQuery.ts
@@ -5,6 +5,7 @@ import { useAuthStore } from "@/store/authStore";
 import { mapUserDataToAuthUser } from "@/utils/mappers/useMappers";
 import { UserData, UpdateUserProfileRequest, UpdateBasicInfoRequest } from "@/types/card";
 import { createDriverProfile, CreateDriverProfileRequest } from "@/lib/apis/driverProfileApi";
+import { createConsumerProfile, CreateConsumerProfileRequest } from "@/lib/apis/consumerProfileApi";
 import { AxiosError } from "axios";
 
 interface UseProfileQueryOptions {
@@ -123,6 +124,18 @@ export const useProfileQuery = (options?: UseProfileQueryOptions) => {
     },
   });
 
+  // 고객 프로필 등록
+  const createConsumerProfileMutation = useMutation({
+    mutationFn: (payload: CreateConsumerProfileRequest) => createConsumerProfile(payload),
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({ queryKey: ["userProfile"] });
+      console.log("[useProfileQuery] 고객 프로필 등록 성공:", response.data);
+    },
+    onError: (err) => {
+      console.error("[useProfileQuery] 고객 프로필 등록 실패:", err);
+    },
+  });
+
   return {
     // 조회 상태
     user: profileQuery.data,
@@ -144,6 +157,11 @@ export const useProfileQuery = (options?: UseProfileQueryOptions) => {
     createDriverProfile: createDriverProfileMutation.mutateAsync,
     isCreatingDriverProfile: createDriverProfileMutation.isPending,
     createDriverProfileError: createDriverProfileMutation.error,
+
+    // 고객 프로필 등록
+    createConsumerProfile: createConsumerProfileMutation.mutateAsync,
+    isCreatingConsumerProfile: createConsumerProfileMutation.isPending,
+    createConsumerProfileError: createConsumerProfileMutation.error,
 
     // 유틸리티
     refetch: profileQuery.refetch,

--- a/src/lib/apis/consumerProfileApi.ts
+++ b/src/lib/apis/consumerProfileApi.ts
@@ -1,0 +1,38 @@
+import apiClient from "../apiClient";
+import type { AreaType } from "@/types/areaTypes";
+import type { ServerMoveType } from "@/types/moveTypes";
+
+// ==================== Types ====================
+
+export interface CreateConsumerProfileRequest {
+  image?: string | null;
+  serviceType: ServerMoveType;
+  areas: AreaType;
+}
+
+export interface ConsumerProfile {
+  id: string;
+  userId: string;
+  image: string | null;
+  serviceType: ServerMoveType;
+  areas: AreaType;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+export interface ApiResponse<T> {
+  statusCode: number;
+  success: boolean;
+  data: T;
+}
+
+// ==================== API Functions ====================
+
+export const createConsumerProfile = async (
+  data: CreateConsumerProfileRequest
+): Promise<ApiResponse<ConsumerProfile>> => {
+  const response = await apiClient.post<ApiResponse<ConsumerProfile>>("/consumers/profile", data);
+
+  return response.data;
+};


### PR DESCRIPTION
## 📌 관련 이슈
Closes #107 

## 🎯 작업 내용

### ✨ 새로운 기능
- **고객 프로필 등록 API 연동**
  - `POST /consumers/profile` 엔드포인트 클라이언트 구현
  - `useProfileQuery` 훅에 `createConsumerProfile` mutation 추가
  - 등록 완료 시 `/landing`으로 자동 리다이렉트

### 🔄 개선 사항
- **로그인 흐름 개선**
  - 기사/고객 모두 프로필 확인 후 적절한 페이지로 리다이렉트
  - 프로필 미등록 시 `/mypage/profile`로, 등록 완료 시 `/landing`으로 이동

- **캐시 관리 강화**
  - 로그아웃 시 React Query 캐시 완전 초기화
  - 사용자 간 데이터 격리 보장 (이전 사용자 프로필 데이터 미노출)

- **역할 기반 접근 제어**
  - `/mypage/basicEdit/[id]` 페이지에 DRIVER 전용 접근 제어 추가
  - `useRef`로 중복 알림 방지
  - 권한 없는 접근 시 명확한 안내 메시지 및 리다이렉트

- **네비게이션 UX 개선**
  - 로그인 상태에서도 Logo 클릭 시 `/landing`으로 이동
  - 모바일/데스크톱 모두 동일한 동작 보장

### 🐛 버그 수정
- useEffect 중복 실행으로 인한 알림 반복 표시 문제 해결
- 로그아웃 후 캐시 잔존 문제 해결

## 🔍 변경 파일
- ✅ `src/lib/apis/consumerProfileApi.ts` (신규)
- ✅ `src/hooks/useProfileQuery.ts`
- ✅ `src/app/mypage/profile/components/ConsumerProfileForm.tsx`
- ✅ `src/app/login/components/LoginForm.tsx`
- ✅ `src/components/ui/nav/nav.tsx`
- ✅ `src/app/mypage/basicEdit/[id]/page.tsx`

## 🧪 테스트 체크리스트
- [x] 고객 회원가입 → 로그인 → 프로필 등록 플로우 정상 동작
- [x] 프로필 등록 완료 후 `/landing` 이동 확인
- [x] 로그아웃 → 새 계정 로그인 시 이전 데이터 미노출 확인
- [x] 고객 계정으로 기사 전용 페이지 접근 시 차단 확인
- [x] 알림이 중복으로 표시되지 않는지 확인
- [x] Nav Logo 클릭 시 `/landing` 이동 확인

## 💡 리뷰 포인트
- `queryClient.clear()` 사용이 적절한지 (선택적 invalidation vs 전체 초기화)
- `useRef`를 사용한 중복 알림 방지 방식이 적절한지
- 역할 기반 접근 제어 패턴의 재사용성 (다른 페이지에도 적용 가능)

## 📝 후속 작업
- 다른 역할 제한 페이지에도 동일한 접근 제어 패턴 적용
- 프로필 이미지 업로드 기능 구현
- 프로필 편집 페이지 통합 검토 (/mypage/profile, /mypage/profile/edit, /mypage/basicEdit/[id])