### PR TITLE
feat: 기사 유저, 견적관리 페이지 ui 마크업 #116

### DIFF
--- a/src/app/quotation/components/TabNavigation.tsx
+++ b/src/app/quotation/components/TabNavigation.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { TabNavigationProps } from "@/types/tabs";
+
+const TabNavigation: React.FC<TabNavigationProps> = ({ tabs }) => {
+  const pathname = usePathname();
+  console.log(pathname);
+
+  return (
+    <div className="border-b border-gray-200 lg:pt-3">
+      <div className="mx-auto flex px-4 lg:max-w-[1400px] lg:gap-0 lg:px-0">
+        {tabs.map((tab) => {
+          const isActive = pathname.includes(tab.path);
+          console.log(isActive);
+          return (
+            <Link
+              key={tab.path}
+              href={`/quotation/${tab.path}`}
+              scroll={false}
+              className={`px-6 py-4 text-lg font-semibold transition-colors ${
+                isActive
+                  ? "border-b-2 border-black text-black"
+                  : "text-gray-400 hover:text-gray-500"
+              }`}
+            >
+              {tab.label}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default TabNavigation;

--- a/src/app/quotation/sent/page.tsx
+++ b/src/app/quotation/sent/page.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import TabNavigation from "../components/TabNavigation";
+import { DRIVER_TAB_LIST } from "@/types/tabs";
+import RequestCard from "@/components/ui/card/RequestCard";
+import { UserData, RequestData, QuotationData } from "@/types/card";
+
+export default function QuotationSentPage() {
+  const BASE_PATH = "/quotation/sent";
+  const requestCardData: {
+    user: UserData;
+    request: RequestData;
+    quotation?: QuotationData;
+  } = {
+    user: {
+      userId: "user-consumer-001",
+      name: "김철수",
+      role: "CONSUMER",
+      email: "kim@test.com",
+      phoneNumber: "010-9876-5432",
+    },
+    request: {
+      requestId: "req-789",
+      serviceType: ["SMALL_MOVE"],
+      departureAddress: "인천시 남동구",
+      arrivalAddress: "경기도 고양시",
+      requestStatement: "PENDING",
+      moveAt: "2024-07-01",
+      createdAt: "2025-09-25",
+    },
+    quotation: {
+      quotationId: "q-123",
+      departureAddress: "서울시 강남구",
+      arrivalAddress: "경기도 성남시",
+      price: 180000,
+      moveAt: "2025-10-15",
+      createdAt: "2025-09-25",
+      quotationStatement: "ACCEPTED",
+    },
+  };
+  const requestCardData2: {
+    user: UserData;
+    request: RequestData;
+    quotation?: QuotationData;
+  } = {
+    user: requestCardData.user,
+    request: {
+      ...requestCardData.request,
+      requestStatement: "COMPLETED",
+    },
+  };
+  return (
+    <div className="flex min-h-[calc(100vh-80px)] flex-col">
+      <div className="flex flex-grow flex-col">
+        <TabNavigation tabs={DRIVER_TAB_LIST} />
+        <section className="flex-grow bg-gray-200 py-6 lg:py-12">
+          <div className="mx-auto grid gap-4 px-4 lg:max-w-[1400px] lg:grid-cols-2 lg:gap-6 lg:px-0">
+            <RequestCard
+              user={requestCardData.user}
+              request={requestCardData.request}
+              quotation={requestCardData.quotation}
+            />
+            <RequestCard
+              user={requestCardData2.user}
+              request={requestCardData2.request}
+              quotation={requestCardData2.quotation}
+            />
+            <RequestCard
+              user={requestCardData2.user}
+              request={requestCardData2.request}
+              quotation={requestCardData2.quotation}
+            />
+            <RequestCard
+              user={requestCardData2.user}
+              request={requestCardData2.request}
+              quotation={requestCardData2.quotation}
+            />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/card/RequestCard.tsx
+++ b/src/components/ui/card/RequestCard.tsx
@@ -7,6 +7,7 @@ import Button from "../Button";
 import UserProfileArea from "../profile/UserProfileArea";
 import { MoveTypeMap, ServerMoveType } from "@/types/moveTypes";
 import { formatDate, simplifyAreaName } from "@/utils/formatRequestData";
+import CardText from "./CardText";
 
 export default function RequestCard({ user, request, quotation }: CommonCardProps) {
   const tags = request?.serviceType;
@@ -29,30 +30,43 @@ export default function RequestCard({ user, request, quotation }: CommonCardProp
   if (request?.requestStatement === "CANCELLED" || quotation?.quotationStatement === "REJECTED") {
     stateMessage = "반려된 요청입니다";
   } else if (request?.requestStatement === "COMPLETED") {
-    stateMessage = "이사가 완료되었습니다";
+    stateMessage = "이사 완료된 견적이에요.";
   } else if (request?.requestStatement === "EXPIRED") {
     stateMessage = "요청이 만료되었습니다";
   }
   return (
-    <BaseCard className="relative gap-4 border border-gray-300 bg-white px-[14px] py-4 lg:gap-4 lg:px-6 lg:py-5">
-      <div className="flex justify-between">
-        {tags && (
-          <div className="flex gap-2">
-            {tags.map((tag, index) => (
-              <Tag
-                key={index}
-                type={MoveTypeMap[tag].clientType}
-                content={MoveTypeMap[tag].content}
-              />
-            ))}
-          </div>
-        )}
-        {requestedAt && <span className="text-sm text-gray-400">{requestedAt}</span>}
+    <BaseCard className="relative justify-between gap-4 border border-gray-300 bg-white px-[14px] py-4 lg:gap-4 lg:px-6 lg:py-5">
+      <div className="flex flex-col gap-4">
+        <div className="flex justify-between">
+          {tags && (
+            <div className="flex gap-2">
+              {tags.map((tag, index) => (
+                <Tag
+                  key={index}
+                  type={MoveTypeMap[tag].clientType}
+                  content={MoveTypeMap[tag].content}
+                />
+              ))}
+            </div>
+          )}
+          {requestedAt && <span className="text-sm text-gray-400">{requestedAt}</span>}
+        </div>
+        <UserProfileArea user={user} request={request} quotation={quotation} show={["name"]} />
+        <MovingInfoViewer info={movingInfo} infoType="route" />
       </div>
-      <UserProfileArea user={user} request={request} quotation={quotation} show={["name"]} />
-      <MovingInfoViewer info={movingInfo} infoType="route" />
-
-      {isDimmed ? (
+      {quotation?.price ? (
+        <div className="flex justify-end">
+          <CardText className="text-lg lg:text-xl">
+            견적 금액 <span className="font-semibold">{quotation.price.toLocaleString()}원</span>
+          </CardText>
+        </div>
+      ) : (
+        <div className="flex gap-2">
+          <Button text="채팅방 개설하기" />
+          <Button size="sm" textSize="mobile" variant="secondary" text="반려" />
+        </div>
+      )}
+      {isDimmed && (
         <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-xl bg-black/50 backdrop-blur-sm">
           {stateMessage && (
             <span className="text-sm font-bold text-white lg:text-base">{stateMessage}</span>
@@ -66,11 +80,6 @@ export default function RequestCard({ user, request, quotation }: CommonCardProp
               className="max-w-[140px] px-3 py-2 text-sm"
             />
           )}
-        </div>
-      ) : (
-        <div className="flex gap-2">
-          {quotation && <Button text="채팅방 개설하기" />}
-          <Button size="sm" textSize="mobile" variant="secondary" text="반려" />
         </div>
       )}
     </BaseCard>

--- a/src/types/tabs.ts
+++ b/src/types/tabs.ts
@@ -1,0 +1,35 @@
+export type TabItem = {
+  label: string;
+  path: string;
+};
+
+// 탭 컴포넌트 Props 타입 정의
+export interface TabNavigationProps {
+  tabs: readonly TabItem[];
+}
+
+export const DRIVER_TABS = {
+  sent: {
+    label: "보낸 견적 조회",
+    path: "sent",
+  },
+  rejected: {
+    label: "반려 요청",
+    path: "rejected",
+  },
+} as const;
+
+export const DRIVER_TAB_LIST = Object.values(DRIVER_TABS);
+
+export const CONSUMER_TABS = {
+  pending: {
+    label: "대기중인 견적",
+    path: "pending",
+  },
+  received: {
+    label: "받았던 견적",
+    path: "received",
+  },
+} as const;
+
+export const CONSUMER_TAB_LIST = Object.values(CONSUMER_TABS);


### PR DESCRIPTION
이슈번호 #116 

작업요약 : 기사 유저, 견적관리 페이지 ui 마크업

[작업내역]

- [X] 탭 네비게이션 컴포넌트 생성
- [X] 기사 유저, 견적관리 페이지 ui 마크업

<img width="2552" height="1347" alt="image" src="https://github.com/user-attachments/assets/e88a630d-07e1-42ec-8f00-a10be8c0582e" />
