### PR TITLE
fix: 프론트 UI, QA 진행 중 #133

### DIFF
--- a/src/app/chat/[roomId]/page.tsx
+++ b/src/app/chat/[roomId]/page.tsx
@@ -140,13 +140,13 @@ export default function ChatRoomPage({ params }: { params: Promise<{ roomId: str
             return (
               <div key={msg.id} className={`flex items-end gap-2 ${isMe ? "justify-end" : ""}`}>
                 {!isMe && (
-                  <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-indigo-200 text-xs font-bold text-indigo-600 md:h-8 md:w-8 md:text-sm">
+                  <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-indigo-200 text-xs font-bold text-blue-500 md:h-8 md:w-8 md:text-sm">
                     {msg.senderAvatar || msg.senderName?.charAt(0)}
                   </div>
                 )}
                 <div
                   className={`max-w-[280px] rounded-2xl p-2.5 text-sm md:max-w-md md:p-3 md:text-base ${
-                    isMe ? "bg-blue-500 text-white" : "bg-white"
+                    isMe ? "bg-primary text-white" : "bg-white"
                   }`}
                 >
                   <p>{msg.content}</p>
@@ -191,7 +191,7 @@ export default function ChatRoomPage({ params }: { params: Promise<{ roomId: str
           />
           <button
             type="submit"
-            className="flex h-8 w-16 items-center justify-center rounded-full bg-blue-500 text-sm font-medium text-white md:h-10 md:w-20 md:text-base"
+            className="bg-primary flex h-8 w-16 items-center justify-center rounded-full text-sm font-medium text-white md:h-10 md:w-20 md:text-base"
           >
             전송
           </button>

--- a/src/app/chat/layout.tsx
+++ b/src/app/chat/layout.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import useChatStore from "@/store/chatStore";
-import { conversations } from "./mock/data";
+import { conversations, messagesByRoomId } from "./mock/data";
 
 export default function ChatLayout({ children }: { children: React.ReactNode }) {
   const { connectSocket, disconnectSocket } = useChatStore();
@@ -33,14 +33,30 @@ export default function ChatLayout({ children }: { children: React.ReactNode }) 
         <aside className="w-80 border-r border-gray-200 bg-white p-4">
           <h2 className="mb-4 text-lg font-bold">대화 목록</h2>
           <ul className="space-y-2">
-            {conversations.map((convo) => (
-              <Link key={convo.id} href={`/chat/${convo.id}`}>
-                <li className="cursor-pointer rounded-lg p-3 transition-colors hover:bg-gray-100">
-                  <p className="text-sm font-semibold">{convo.name}</p>
-                  <p className="mt-1 truncate text-xs text-gray-600">{convo.lastMessage}</p>
-                </li>
-              </Link>
-            ))}
+            {conversations.map((convo) => {
+              const roomMessages = messagesByRoomId[convo.id] || [];
+              const lastMsg = roomMessages.length
+                ? roomMessages[roomMessages.length - 1]
+                : undefined;
+              const avatarText =
+                lastMsg?.senderAvatar ?? lastMsg?.senderName?.charAt(0) ?? convo.name.charAt(0);
+
+              return (
+                <Link key={convo.id} href={`/chat/${convo.id}`}>
+                  <li className="cursor-pointer rounded-lg p-3 transition-colors hover:bg-gray-100">
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-indigo-200 text-xs font-bold text-blue-500 md:h-8 md:w-8 md:text-sm">
+                        {avatarText}
+                      </div>
+                      <div>
+                        <p className="text-sm font-semibold">{convo.name}</p>
+                        <p className="mt-1 truncate text-xs text-gray-600">{convo.lastMessage}</p>
+                      </div>
+                    </div>
+                  </li>
+                </Link>
+              );
+            })}
           </ul>
         </aside>
 
@@ -109,18 +125,38 @@ export default function ChatLayout({ children }: { children: React.ReactNode }) 
 
               <div className="overflow-y-auto p-4">
                 <ul className="space-y-2">
-                  {conversations.map((convo) => (
-                    <Link
-                      key={convo.id}
-                      href={`/chat/${convo.id}`}
-                      onClick={() => setIsMobileMenuOpen(false)}
-                    >
-                      <li className="cursor-pointer rounded-lg p-3 transition-colors hover:bg-gray-100">
-                        <p className="text-sm font-semibold">{convo.name}</p>
-                        <p className="mt-1 truncate text-xs text-gray-600">{convo.lastMessage}</p>
-                      </li>
-                    </Link>
-                  ))}
+                  {conversations.map((convo) => {
+                    const roomMessages = messagesByRoomId[convo.id] || [];
+                    const lastMsg = roomMessages.length
+                      ? roomMessages[roomMessages.length - 1]
+                      : undefined;
+                    const avatarText =
+                      lastMsg?.senderAvatar ??
+                      lastMsg?.senderName?.charAt(0) ??
+                      convo.name.charAt(0);
+
+                    return (
+                      <Link
+                        key={convo.id}
+                        href={`/chat/${convo.id}`}
+                        onClick={() => setIsMobileMenuOpen(false)}
+                      >
+                        <li className="cursor-pointer rounded-lg p-3 transition-colors hover:bg-gray-100">
+                          <div className="flex items-center gap-3">
+                            <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-indigo-200 text-xs font-bold text-indigo-600 md:h-8 md:w-8 md:text-sm">
+                              {avatarText}
+                            </div>
+                            <div>
+                              <p className="text-sm font-semibold">{convo.name}</p>
+                              <p className="mt-1 truncate text-xs text-gray-600">
+                                {convo.lastMessage}
+                              </p>
+                            </div>
+                          </div>
+                        </li>
+                      </Link>
+                    );
+                  })}
                 </ul>
               </div>
             </div>

--- a/src/app/chat/mock/data.ts
+++ b/src/app/chat/mock/data.ts
@@ -55,7 +55,7 @@ export interface Conversation {
 export const conversations: Conversation[] = [
   { id: "1", name: "김기사님 (용달이사)", lastMessage: "네, 12월 첫째 주 가능합니다." },
   { id: "2", name: "박사장님 (포장이사)", lastMessage: "견적 확인 부탁드립니다." },
-  { id: "3", name: "최팀장님 (사무실이사)", lastMessage: "알겠습니다." },
+  { id: "3", name: "최팀장님 (사무실이사)", lastMessage: "" },
 ];
 
 // 2. 채팅방 ID별 실제 대화 내용 데이터

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { conversations } from "./mock/data";
+import { conversations, messagesByRoomId } from "./mock/data";
 
 export default function ChatHomePage() {
   return (
@@ -42,33 +42,47 @@ export default function ChatHomePage() {
         {/* 채팅방 목록 */}
         <div className="p-4">
           <div className="space-y-3">
-            {conversations.map((convo) => (
-              <Link key={convo.id} href={`/chat/${convo.id}`}>
-                <div className="rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:bg-gray-50 active:bg-gray-100">
-                  <div className="flex items-center justify-between">
-                    <div className="flex-1">
-                      <h3 className="mb-1 font-semibold text-gray-900">{convo.name}</h3>
-                      <p className="truncate text-sm text-gray-600">{convo.lastMessage}</p>
-                    </div>
-                    <div className="ml-3">
-                      <svg
-                        className="h-5 w-5 text-gray-400"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M9 5l7 7-7 7"
-                        />
-                      </svg>
+            {conversations.map((convo) => {
+              const roomMessages = messagesByRoomId[convo.id] || [];
+              const lastMsg = roomMessages.length
+                ? roomMessages[roomMessages.length - 1]
+                : undefined;
+              const avatarText =
+                lastMsg?.senderAvatar ?? lastMsg?.senderName?.charAt(0) ?? convo.name.charAt(0);
+
+              return (
+                <Link key={convo.id} href={`/chat/${convo.id}`}>
+                  <div className="rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:bg-gray-50 active:bg-gray-100">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-indigo-200 text-xs font-bold text-blue-500 md:h-10 md:w-10 md:text-sm">
+                          {avatarText}
+                        </div>
+                        <div className="flex-1">
+                          <h3 className="mb-1 font-semibold text-gray-900">{convo.name}</h3>
+                          <p className="truncate text-sm text-gray-600">{convo.lastMessage}</p>
+                        </div>
+                      </div>
+                      <div className="ml-3">
+                        <svg
+                          className="h-5 w-5 text-gray-400"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M9 5l7 7-7 7"
+                          />
+                        </svg>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </Link>
-            ))}
+                </Link>
+              );
+            })}
           </div>
 
           {/* 빈 상태 또는 추가 정보 */}

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -29,21 +29,21 @@ export default function Landing() {
         <div className="flex w-full flex-col items-center gap-4 px-4 md:hidden">
           <Image
             src={MovingSmall.src}
-            className="w-full max-w-[360px] cursor-pointer"
+            className="w-full max-w-[360px]"
             alt="소형이사"
             width={360}
             height={200}
           />
           <Image
             src={MovingHome.src}
-            className="w-full max-w-[360px] cursor-pointer"
+            className="w-full max-w-[360px]"
             alt="가정이사"
             width={360}
             height={200}
           />
           <Image
             src={MovingBusiness.src}
-            className="w-full max-w-[360px] cursor-pointer"
+            className="w-full max-w-[360px]"
             alt="기업, 사무실 이사"
             width={360}
             height={200}
@@ -54,21 +54,21 @@ export default function Landing() {
         <div className="hidden w-full flex-col items-center gap-4 px-6 md:flex lg:hidden">
           <Image
             src={MovingSmall.src}
-            className="w-full max-w-[600px] cursor-pointer"
+            className="w-full max-w-[600px]"
             alt="소형이사"
             width={600}
             height={300}
           />
           <Image
             src={MovingHome.src}
-            className="w-full max-w-[600px] cursor-pointer"
+            className="w-full max-w-[600px]"
             alt="가정이사"
             width={600}
             height={300}
           />
           <Image
             src={MovingBusiness.src}
-            className="w-full max-w-[600px] cursor-pointer"
+            className="w-full max-w-[600px]"
             alt="기업, 사무실 이사"
             width={600}
             height={300}
@@ -77,28 +77,10 @@ export default function Landing() {
 
         {/* 데스크톱 레이아웃 */}
         <div className="hidden lg:flex lg:items-start lg:justify-center lg:gap-6">
-          <Image
-            src={MovingSmallMd.src}
-            className="cursor-pointer"
-            alt="소형이사"
-            width={432}
-            height={508}
-          />
+          <Image src={MovingSmallMd.src} alt="소형이사" width={432} height={508} />
           <div className="flex flex-col gap-6">
-            <Image
-              src={MovingHomeMd.src}
-              className="cursor-pointer"
-              alt="가정이사"
-              width={764}
-              height={241}
-            />
-            <Image
-              src={MovingBusinessMd.src}
-              className="cursor-pointer"
-              alt="기업, 사무실 이사"
-              width={764}
-              height={241}
-            />
+            <Image src={MovingHomeMd.src} alt="가정이사" width={764} height={241} />
+            <Image src={MovingBusinessMd.src} alt="기업, 사무실 이사" width={764} height={241} />
           </div>
         </div>
 

--- a/src/app/login/components/SocialLogin.tsx
+++ b/src/app/login/components/SocialLogin.tsx
@@ -13,23 +13,11 @@ export default function SocialLogin() {
           className="cursor-pointer"
           src={Google.src}
           alt="소셜로그인"
-          width={100}
-          height={100}
+          width={54}
+          height={54}
         />
-        <Image
-          className="cursor-pointer"
-          src={Kakao.src}
-          alt="소셜로그인"
-          width={100}
-          height={100}
-        />
-        <Image
-          className="cursor-pointer"
-          src={Naver.src}
-          alt="소셜로그인"
-          width={100}
-          height={100}
-        />
+        <Image className="cursor-pointer" src={Kakao.src} alt="소셜로그인" width={54} height={54} />
+        <Image className="cursor-pointer" src={Naver.src} alt="소셜로그인" width={54} height={54} />
       </div>
     </div>
   );

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -231,7 +231,10 @@ export default function Signup() {
 
       <div className="mx-auto flex max-w-160 flex-row justify-center">
         <span>이미 무빙 회원이신가요?</span>
-        <Link href="/login" className="text-primary mb-3 ml-2 font-semibold">
+        <Link
+          href="/login"
+          className="text-primary mb-3 ml-2 font-semibold underline underline-offset-2"
+        >
           로그인
         </Link>
       </div>
@@ -249,13 +252,13 @@ export default function Signup() {
           </Link>
         </div>
       </div>
-      <WelcomeOverlay 
-        open={showOverlay} 
+      <WelcomeOverlay
+        open={showOverlay}
         onClose={() => {
           setShowOverlay(false);
           // 오버레이 닫힐 때 프로필 등록 페이지로 이동 (role 쿼리 전달)
           router.push(`/mypage/profile?role=${signupRole}`);
-        }} 
+        }}
       />
     </div>
   );

--- a/src/components/chat/QuotationMessage.tsx
+++ b/src/components/chat/QuotationMessage.tsx
@@ -61,7 +61,7 @@ export default function QuotationMessage({ quotation, messageId }: QuotationMess
       <div className="space-y-2">
         <div className="flex items-baseline justify-between border-b pb-2">
           <span className="text-sm text-gray-600">견적 금액 &nbsp;</span>
-          <span className="text-2xl font-bold text-blue-600">
+          <span className="text-2xl font-bold text-blue-500">
             {quotation.price.toLocaleString()}원
           </span>
         </div>
@@ -91,7 +91,7 @@ export default function QuotationMessage({ quotation, messageId }: QuotationMess
       {isCustomer && quotation.status === "SUBMITTED" && (
         <button
           onClick={handleAccept}
-          className="mt-4 w-full rounded-lg bg-blue-500 py-2 font-medium text-white hover:bg-blue-600"
+          className="bg-primary mt-4 w-full rounded-lg py-2 font-medium text-white hover:bg-blue-500"
         >
           견적 수락하기
         </button>

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -163,7 +163,7 @@ export default function Input({
           onClick={() => setShowPassword((s: boolean) => !s)}
           className="absolute right-3 flex items-center justify-center"
         >
-          <Image src={showPassword ? CloseEyeIcon : EyeIcon} alt="" width={20} height={20} />
+          <Image src={showPassword ? EyeIcon : CloseEyeIcon} alt="" width={20} height={20} />
         </button>
       )}
 


### PR DESCRIPTION
## 설명
프론트엔드 UX·타입 안정성 개선을 위한 소규모 변경입니다. 사용자 혼동을 줄이고 UI 일관성을 높입니다.

### 변경 내용
- `Input.tsx`  
  - 비밀번호 보이기/숨기기 토글 아이콘 로직을 반전하여 상태와 아이콘이 직관적으로 일치하도록 수정.
- `WelcomeOverlay.tsx`  
  - framer-motion transition 타입을 `as const`로 변경하여 `any` 제거.
- `chat/page.tsx`, `chat/[roomId]/page.tsx`, `chat/layout.tsx`  
  - 채팅 목록(사이드바/모바일 포함)에 아바타(초기 문자) 추가.
  - 데스크톱 이미지에서 `cursor-pointer` 클래스 제거.
- `QuotationMessage.tsx`  
  - 견적 금액 텍스트 및 수락 버튼을 전역 primary 색상으로 변경(버튼: `bg-[var(--color-primary)]`, hover: `bg-[var(--color-primary-softer)]` 권장).

### 테스트 체크리스트
- [x] 비밀번호 토글 아이콘/동작 일치 확인  
- [x] 데스크톱 랜딩 이미지에 포인터 없음 확인  
- [x] 채팅 목록 아바타 표시 확인 (데스크톱/모바일)  
- [x] 견적 수락 버튼 색상/hover 동작 확인  
- [x] WelcomeOverlay 애니메이션 정상 동작 확인  
- [x] 반응형 레이아웃 깨짐 없음