### PR TITLE
feat: review api 연결, test는 X #123

### DIFF
--- a/src/lib/apis/reviewApi.ts
+++ b/src/lib/apis/reviewApi.ts
@@ -18,6 +18,36 @@ export interface CreateReviewResponse {
   quotationId: string;
   createdAt: string;
   updatedAt: string;
+  deletedAt: string | null;
+}
+
+// 개별 리뷰 응답 타입
+export interface ReviewResponseDto {
+  id: string;
+  rating: number;
+  content: string;
+  consumerName: string;
+  createdAt: string;
+}
+
+// 기사별 리뷰 목록 조회 응답 타입 (커서 페이지네이션)
+export interface GetDriverReviewsResponse {
+  reviews: ReviewResponseDto[];
+  nextCursor: string | null;
+}
+
+// 기사 평점 분포 응답 타입
+export interface DriverRatingDistributionResponse {
+  driverId: string;
+  totalReviews: number;
+  averageRating: number;
+  ratings: {
+    1: number;
+    2: number;
+    3: number;
+    4: number;
+    5: number;
+  };
 }
 
 // 리뷰 목록 조회 응답 타입 (임시 - BE API가 구현되면 수정 필요)
@@ -89,25 +119,32 @@ export const getWrittenReviews = async (
 };
 
 /**
- * 특정 기사의 리뷰 목록 조회
- * TODO: BE API가 구현되면 실제 API 연동 필요
+ * 특정 기사의 리뷰 목록 조회 (커서 기반 페이지네이션)
  */
 export const getDriverReviews = async (
   driverId: string,
-  page: number = 1,
-  limit: number = 5
-): Promise<GetReviewsResponse> => {
-  // 임시로 빈 배열 반환
-  // 실제 구현 시 아래와 같은 형태로 작성
-  // const response = await apiClient.get<GetReviewsResponse>(`/reviews/driver/${driverId}`, {
-  //   params: { page, limit }
-  // });
-  // return response.data;
+  limit: number = 5,
+  cursor?: string
+): Promise<GetDriverReviewsResponse> => {
+  const params: { limit: number; cursor?: string } = { limit };
+  if (cursor) {
+    params.cursor = cursor;
+  }
 
-  return {
-    reviews: [],
-    totalCount: 0,
-    page,
-    totalPages: 0,
-  };
+  const response = await apiClient.get<GetDriverReviewsResponse>(`/reviews/drivers/${driverId}`, {
+    params,
+  });
+  return response.data;
+};
+
+/**
+ * 특정 기사의 평점 분포 조회
+ */
+export const getDriverRatingDistribution = async (
+  driverId: string
+): Promise<DriverRatingDistributionResponse> => {
+  const response = await apiClient.get<DriverRatingDistributionResponse>(
+    `/reviews/drivers/${driverId}/rating`
+  );
+  return response.data;
 };


### PR DESCRIPTION
# Review API 백엔드 연결

## 변경 사항

### 타입 정의 추가
- `ReviewResponseDto`: 개별 리뷰 응답 타입
- `GetDriverReviewsResponse`: 기사별 리뷰 목록 조회 응답 (커서 기반 페이지네이션)
- `DriverRatingDistributionResponse`: 기사 평점 분포 응답 타입
- `CreateReviewResponse`에 `deletedAt` 필드 추가

### API 함수 구현
- ✅ `getDriverReviews`: 특정 기사의 리뷰 목록 조회 (커서 페이지네이션)
- ✅ `getDriverRatingDistribution`: 특정 기사의 평점 분포 조회
- ✅ `createReview`: 리뷰 작성 (기존 구현 유지)

### API 엔드포인트
GET /api/reviews/drivers/:driverId # 기사 리뷰 목록 (limit, cursor)
GET /api/reviews/drivers/:driverId/rating # 기사 평점 분포
POST /api/reviews # 리뷰 작성


## 참고사항
- 백엔드 Review API 스펙에 맞춰 구현 완료
- 커서 기반 페이지네이션 적용
- `getWritableReviews`, `getWrittenReviews`는 백엔드 API 미구현으로 추후 작업 예정